### PR TITLE
[feat] 휴면 계정 처리

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.38/57f8f5e02e92a30fd21b80cbd426a4172b5f8e29/lombok-1.18.38.jar" />
+        </processorPath>
+        <module name="backend.main" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/modules/backend.main.iml
+++ b/.idea/modules/backend.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../backend/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../backend/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/backend/src/main/java/com/example/backend/auth/user/model/DormantActivationToken.java
+++ b/backend/src/main/java/com/example/backend/auth/user/model/DormantActivationToken.java
@@ -1,0 +1,35 @@
+package com.example.backend.auth.user.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "dormant_activation_token")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DormantActivationToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 64)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+}

--- a/backend/src/main/java/com/example/backend/auth/user/model/dto/ReactivateRequest.java
+++ b/backend/src/main/java/com/example/backend/auth/user/model/dto/ReactivateRequest.java
@@ -1,0 +1,12 @@
+package com.example.backend.auth.user.model.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ReactivateRequest {
+
+    @NotBlank
+    private String token;
+}

--- a/backend/src/main/java/com/example/backend/auth/user/repository/DormantActivationTokenRepository.java
+++ b/backend/src/main/java/com/example/backend/auth/user/repository/DormantActivationTokenRepository.java
@@ -1,0 +1,13 @@
+package com.example.backend.auth.user.repository;
+
+import com.example.backend.auth.user.model.DormantActivationToken;
+import com.example.backend.auth.user.model.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DormantActivationTokenRepository extends JpaRepository<DormantActivationToken, Long> {
+    Optional<DormantActivationToken> findByToken(String token);
+    
+    void deleteByUser(Users user);
+}

--- a/backend/src/main/java/com/example/backend/auth/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/auth/user/repository/UserRepository.java
@@ -1,12 +1,18 @@
 package com.example.backend.auth.user.repository;
 
 import com.example.backend.auth.user.model.Users;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<Users, UUID> {
+
+    Page<Users> findByStatusAndLastLoginBefore(Users.UserStatus status, LocalDateTime before, Pageable pageable);
+
     Optional<Users> findByEmail(String email);
 
     boolean existsByEmail(String email);

--- a/backend/src/main/java/com/example/backend/auth/user/scheduler/UserDormancyScheduler.java
+++ b/backend/src/main/java/com/example/backend/auth/user/scheduler/UserDormancyScheduler.java
@@ -1,0 +1,53 @@
+package com.example.backend.auth.user.scheduler;
+
+import com.example.backend.auth.email.service.EmailService;
+import com.example.backend.auth.user.model.Users;
+import com.example.backend.auth.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class UserDormancyScheduler {
+
+    private final EmailService emailService;
+    private final UserRepository userRepository;
+
+    @Value("${user.dormancy.period.days}")
+    private long dormancyPeriodDays;
+
+    @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시에 실행
+    @Transactional
+    public void processDormantUsers() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(dormancyPeriodDays);
+
+        int pageSize = 100;
+        Pageable pageable = PageRequest.of(0, pageSize);
+        Page<Users> page;
+        do {
+            page = userRepository.findByStatusAndLastLoginBefore(Users.UserStatus.ACTIVE, threshold, pageable);
+            for (Users user : page.getContent()) {
+                // 상태 변경
+                user.setStatus(Users.UserStatus.DORMANT);
+                userRepository.save(user);
+                // 이메일 발송: 휴면 안내
+                emailService.sendDormantNotificationEmail(user.getEmail());
+            }
+            if (page.hasNext()) {
+                pageable = page.nextPageable();
+            } else {
+                break;
+            }
+        } while (true);
+    }
+
+}
+

--- a/backend/src/main/java/com/example/backend/auth/user/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/example/backend/auth/user/service/CustomUserDetailsService.java
@@ -1,11 +1,11 @@
 package com.example.backend.auth.user.service;
 
+import com.example.backend.auth.user.model.Users;
 import com.example.backend.auth.user.repository.UserRepository;
 import com.example.backend.exception.CustomException;
 import com.example.backend.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -23,22 +23,28 @@ public class CustomUserDetailsService implements UserDetailsService {
             throws UsernameNotFoundException {
         log.info("[UserDetailsService] 사용자 인증 요청 수신: username={}", username);
 
-        return userRepository.findById(username)
+        return userRepository.findByEmail(username)
                 .map(users -> {
                     String[] rolesArray = users.getRoles().split(",");
                     log.info("[UserDetailsService] 사용자 정보 조회 성공: email={}, roles={}", users.getEmail(), users.getRoles());
-                    if (users.getDeletedAt() != null) {
-                        throw new CustomException(ErrorCode.USER_NOT_FOUND);
+                    Users.UserStatus userStatus = users.getStatus();
+                    if (userStatus.equals(Users.UserStatus.DORMANT)) {
+                        throw new CustomException(ErrorCode.USER_DORMANT);
+                    } else if (userStatus.equals(Users.UserStatus.UNVERIFIED)) {
+                        throw new CustomException(ErrorCode.USER_UNVERIFIED);
+                    } else if (userStatus.equals(Users.UserStatus.WITHDRAWN)) {
+                        throw new CustomException(ErrorCode.USER_WITHDRAWN);
                     }
-                    return User.builder()
+                    /*User.builder()
                             .username(users.getEmail())
                             .password(users.getPassword())
                             .roles(rolesArray)
-                            .build();
+                            .build();*/
+                    return new CustomUserDetails(users);
                 })
                 .orElseThrow(() -> {
                     log.warn("[UserDetailsService] 사용자 조회 실패: 존재하지 않는 username={}", username);
-                    return new UsernameNotFoundException("해당 이메일의 사용자를 찾을 수 없습니다: " + username);
+                    return new CustomException(ErrorCode.USER_NOT_FOUND);
                 });
     }
 

--- a/backend/src/main/java/com/example/backend/auth/user/service/DormantTokenService.java
+++ b/backend/src/main/java/com/example/backend/auth/user/service/DormantTokenService.java
@@ -1,0 +1,113 @@
+package com.example.backend.auth.user.service;
+
+import com.example.backend.auth.user.model.DormantActivationToken;
+import com.example.backend.auth.user.model.Users;
+import com.example.backend.auth.user.repository.DormantActivationTokenRepository;
+import com.example.backend.auth.user.repository.UserRepository;
+import com.example.backend.exception.CustomException;
+import com.example.backend.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DormantTokenService {
+
+    private final DormantActivationTokenRepository tokenRepository;
+    private final UserRepository userRepository;
+
+    @Value("${user.dormancy.token.expiration.hours:24}")
+    private long tokenExpirationHours;
+
+
+    /**
+     * 휴면 재활성화를 위한 토큰 생성.
+     * - 기존에 남아있는 토큰들은 삭제
+     * - 새 토큰 발급, 저장하여 반환
+     *
+     * @param user 휴면 대상 사용자 엔티티 (Users)
+     * @return 생성된 토큰 문자열
+     */
+    @Transactional
+    public String createDormantReactivationToken(Users user) {
+        // 사용자가 null이거나 DB에 없으면 예외
+        if (user == null || user.getId() == null) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        // 기존 토큰 삭제 (여러 개 있을 수 있으므로 모두 삭제)
+        tokenRepository.deleteByUser(user);
+
+        // 토큰 문자열 생성: UUID 등
+        String token = UUID.randomUUID().toString();
+
+        // 만료 시각 계산: 현재 시각 + 만료 시간
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expiresAt = now.plusHours(tokenExpirationHours);
+
+        DormantActivationToken entity = DormantActivationToken.builder()
+                .token(token)
+                .user(user)
+                .createdAt(now)
+                .expiresAt(expiresAt)
+                .build();
+
+        tokenRepository.save(entity);
+        return token;
+    }
+
+    /**
+     * 토큰을 검증하고, 유효하면 관련된 Users 엔티티를 반환.
+     * - 토큰이 없거나 만료되었거나 이미 사용되었으면 예외 발생
+     *
+     * @param tokenStr 클라이언트로부터 전달된 토큰 문자열
+     * @return 토큰이 유효한 경우 해당 사용자 엔티티
+     */
+    @Transactional(readOnly = true)
+    public Users validateAndGetUserByToken(String tokenStr) {
+        DormantActivationToken tokenEntity = tokenRepository.findByToken(tokenStr)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_DORMANT_TOKEN_INVALID));
+
+        // 만료 여부 확인
+        if (tokenEntity.getExpiresAt().isBefore(LocalDateTime.now())) {
+            // 만료된 토큰: 삭제 후 예외
+            tokenRepository.delete(tokenEntity);
+            throw new CustomException(ErrorCode.USER_DORMANT_TOKEN_EXPIRED);
+        }
+
+        Users user = tokenEntity.getUser();
+        if (user == null) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+        user.setStatus(Users.UserStatus.ACTIVE);
+        user.setLastLogin(LocalDateTime.now());
+        userRepository.save(user);
+
+        return user;
+    }
+
+    /**
+     * 재활성화 완료 후 토큰 삭제.
+     *
+     * @param tokenStr 사용이 끝난 토큰 문자열
+     */
+    @Transactional
+    public void deleteToken(String tokenStr) {
+        tokenRepository.findByToken(tokenStr).ifPresent(tokenRepository::delete);
+    }
+
+    /**
+     * 사용자 기준으로 토큰 모두 삭제 (안전용).
+     *
+     * @param user
+     */
+    @Transactional
+    public void deleteTokensByUser(Users user) {
+        tokenRepository.deleteByUser(user);
+    }
+}

--- a/backend/src/main/java/com/example/backend/exception/ErrorCode.java
+++ b/backend/src/main/java/com/example/backend/exception/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode {
     USER_UNVERIFIED(HttpStatus.UNAUTHORIZED, "USER_UNVERIFIED_401", "이메일 인증을 완료하지 않은 유저입니다."),
     USER_EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "USER_EMAIL_DUPLICATED_400", "이미 사용 중인 이메일입니다."),
     USER_PASSWORD_RESET_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "USER_PASSWORD_RESET_TOKEN_INVALID_401", "유효하지 않은 토큰입니다."),
+    USER_DORMANT_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "USER_DORMANT_TOKEN_INVALID_401", "유효하지 않은 재활성화 토큰입니다."),
+    USER_DORMANT_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "USER_DORMANT_TOKEN_EXPIRED_401", "휴면 재활성화 토큰이 만료되었습니다."),
 
     /**
      * Auth/Email 도메인에서 사용하는 ErrorCode

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
-#  profiles:
-#    active: dev
+  #  profiles:
+  #    active: dev
   datasource:
     url: ${DB_URL}
     username: ${DB_USER}
@@ -66,6 +66,13 @@ jwt:
   refresh-name: ${JWT_REFRESH_NAME}
   access-expiration: ${JWT_ACCESS_EXPIRATION}
   refresh-expiration: ${JWT_REFRESH_EXPIRATION}
+user:
+  dormancy:
+    period:
+      days: ${USER_DORMANCY_DAYS}
+    token:
+      expiration:
+        hours: ${USER_DORMANCY_TOKEN_EXPIRATION}
 app:
   frontend:
     url: ${VERIFY_URL}


### PR DESCRIPTION
**1. 변경 요약 (Summary of Changes)**
- 일정 기간 접속하지 않은 유저를 휴면(Dormant) 상태로 전환하는 기능을 구현했습니다. 
- Spring Scheduler에서 매일 새벽 3시마다 lastLogin을 확인해 status를 dormant로 바꾸고 재활성화 링크를 이메일로 보냈습니다. 
- 기간은 application.yml의 user.dormancy.period.days에서 환경 변수로 관리됩니다. 
- 재활성화 토큰의 만료는 user.dormancy.token.expiration.hours에서 관리됩니다.

**2. 관련 이슈 (Related Issues)**
- 연결된 이슈 번호: `#21`

**4. 체크리스트 (Checklist)**
- [ ] 코드 컨벤션을 준수했는가? (파일명, 네이밍, 포맷 등)
- [ ] 새로운 기능/버그 수정에 대한 단위 테스트 작성 및 통과했는가?
- [ ] 통합 테스트 및 시나리오 테스트를 통과했는가?
- [ ] 문서(Docs) 업데이트가 필요한 경우 반영했는가?
- [ ] 주요 로직에 적절한 주석이 포함되었는가?
- [ ] 보안/성능 고려 사항 검토했는가?
- [ ] 관련 브랜치 전략 및 머지 대상이 적절한가?