### PR TITLE
[feat] 빌드 로그 list 반환 기능 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
     implementation 'org.mariadb.jdbc:mariadb-java-client:3.1.4'
+    implementation 'org.jsoup:jsoup:1.15.4'
 
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/backend/src/main/java/com/example/backend/build/model/dto/BuildLogRequestDto.java
+++ b/backend/src/main/java/com/example/backend/build/model/dto/BuildLogRequestDto.java
@@ -1,0 +1,28 @@
+package com.example.backend.build.model.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+
+public class BuildLogRequestDto {
+
+
+
+
+    private String jobName;
+    private String buildNumber;
+
+
+
+
+
+
+
+}

--- a/backend/src/main/java/com/example/backend/build/model/dto/BuildLogResponseDto.java
+++ b/backend/src/main/java/com/example/backend/build/model/dto/BuildLogResponseDto.java
@@ -1,0 +1,44 @@
+package com.example.backend.build.model.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.jsoup.nodes.Element;
+
+import java.util.List;
+
+
+public class BuildLogResponseDto {
+
+
+
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Builder
+    public static class BuildLogDto {
+        private List<String> log;
+
+
+        public static BuildLogDto getLog(Element pre) {
+            String rawLog = pre.text();
+            List<String> lines = List.of(rawLog.split("\n"));
+            return BuildLogDto.builder()
+                    .log(lines)
+                    .build();
+        }
+
+
+
+    }
+
+
+
+
+
+
+
+}

--- a/backend/src/main/java/com/example/backend/build/model/dto/BuildStreamLogResponseDto.java
+++ b/backend/src/main/java/com/example/backend/build/model/dto/BuildStreamLogResponseDto.java
@@ -1,0 +1,40 @@
+package com.example.backend.build.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.jsoup.nodes.Element;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class BuildStreamLogResponseDto {
+
+
+
+
+
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Builder
+    public static class BuildStreamLogDto {
+        private List<String> log;
+
+
+        public static BuildStreamLogResponseDto.BuildStreamLogDto getStreamLog(String body) {
+            List<String> lines = Arrays.asList(body.split("\\r?\\n"));
+            return BuildStreamLogResponseDto.BuildStreamLogDto.builder()
+                    .log(lines)
+                    .build();
+        }
+
+
+
+    }
+
+
+
+}

--- a/backend/src/main/java/com/example/backend/build/service/BuildService.java
+++ b/backend/src/main/java/com/example/backend/build/service/BuildService.java
@@ -1,30 +1,38 @@
 package com.example.backend.build.service;
 
 
-import com.example.backend.build.model.dto.BuildResponseDto;
-import com.example.backend.build.model.dto.BuildQueryRequestDto;
+import com.example.backend.build.model.dto.*;
 import com.example.backend.build.model.JobType;
-import com.example.backend.build.model.dto.BuildTriggerRequestDto;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.web.util.UriComponentsBuilder;
 
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class BuildService {
 
     private final RestTemplate restTemplate;
-
 
 
     // 빌드 내역 조회 최신,빌드 내역
@@ -50,8 +58,6 @@ public class BuildService {
     }
 
 
-
-
     // job 빌드 트리거
     public void triggerJenkinsBuild(BuildTriggerRequestDto requestDto) {
         String jenkinsUrl = "http://15.164.104.2:8080";
@@ -59,21 +65,6 @@ public class BuildService {
         String username = "admin";
         String apiToken = "114cf329b1dbcc4e92dfca3c0d46f3c980";
 
-
-
-//        //
-//        String crumbUrl = jenkinsUrl + "/crumbIssuer/api/json";
-//        HttpHeaders crumbHeaders = new HttpHeaders();
-//        crumbHeaders.setBasicAuth(username, apiToken);
-//        HttpEntity<String> crumbRequest = new HttpEntity<>(crumbHeaders);
-//
-//        ResponseEntity<Map> crumbResponse = restTemplate.exchange(
-//                crumbUrl, HttpMethod.GET, crumbRequest, Map.class
-//        );
-//
-//        String crumb = (String) crumbResponse.getBody().get("crumb");
-//        String crumbField = (String) crumbResponse.getBody().get("crumbRequestField");
-//        //
 
 
 
@@ -99,10 +90,6 @@ public class BuildService {
             log.error("❌ 빌드 트리거 실패 - jobName: {}", jobName, e);
         }
     }
-
-
-
-
 
 
     // 빌드 내역 조회
@@ -139,6 +126,76 @@ public class BuildService {
     }
 
 
+    public BuildLogResponseDto.BuildLogDto getBuildLog(String jobName, String buildNumber) {
+
+
+        String jenkinsUrl = "http://15.164.104.2:8080";
+        String username = "admin";
+        String apiToken = "114cf329b1dbcc4e92dfca3c0d46f3c980";
+
+        String triggerUrl = jenkinsUrl + "/job/" + jobName + "/" + buildNumber + "/console";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBasicAuth(username, apiToken);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(triggerUrl, HttpMethod.GET, entity, String.class);
+
+            log.info("Jenkins API 응답 수신 완료 - Status: {}", response.getStatusCode());
+
+
+            String html = response.getBody();
+            Document doc = Jsoup.parse(html);
+            Element pre = doc.selectFirst("pre.console-output");
+
+
+            log.info("response: {}", pre);
+
+
+            log.info("Jenkins API 응답 수신 완료 - Status: {}", response.getStatusCode());
+
+
+            return BuildLogResponseDto.BuildLogDto.getLog(pre);
+
+
+        } catch (Exception e) {
+            log.error("Jenkins API 호출 실패 - jobName: {}", jobName, e);
+            throw new RuntimeException("Jenkins API 호출 실패", e);
+        }
+
+
+    }
+
+
+
+    public BuildStreamLogResponseDto.BuildStreamLogDto getStreamLog(String jobName, String buildNumber) {
+
+        String jenkinsUrl = "http://15.164.104.2:8080";
+        String username = "admin";
+        String apiToken = "114cf329b1dbcc4e92dfca3c0d46f3c980";
+
+
+        URI uri = UriComponentsBuilder
+                .fromHttpUrl(jenkinsUrl + "/job/" + jobName + "/" + buildNumber + "/logText/progressiveText")
+                .build()
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBasicAuth(username, apiToken);
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(uri, HttpMethod.GET, entity, String.class);
+
+
+
+
+
+
+        return BuildStreamLogResponseDto.BuildStreamLogDto.getStreamLog(response.getBody());
+
+    }
+
 
 
 
@@ -170,8 +227,4 @@ public class BuildService {
         }
     }
 
-    public String getBuildLog(String jobName, int buildNumber) {
-        log.warn("getBuildLog() 아직 구현되지 않음 - jobName: {}, buildNumber: {}", jobName, buildNumber);
-        return null;
-    }
 }

--- a/backend/src/main/java/com/example/backend/config/CorsConfig.java
+++ b/backend/src/main/java/com/example/backend/config/CorsConfig.java
@@ -15,7 +15,7 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         // 허용할 오리진 (vue dev 서버 등)
-        config.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:3000"));
+        config.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:3000", "http://127.0.0.1:5500"));
         // 허용할 HTTP 메서드
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         // 허용할 헤더


### PR DESCRIPTION
- job 의 빌드번호 log
- job 의 빌드시 생성되는 console log API

---
name: "Pull Request"
about: "새로운 Pull Request 생성 시 사용합니다"
title: "[FEAT] Jenkins Job  콘솔 로그 조회 기능 추가"
labels: ["jenkins", "backend", "log"]
assignees: [leewoojin12]
---

**1. 변경 요약 (Summary of Changes)**
- Jenkins REST API를 통해 Job의  빌드번호의 log 를 조회하는 기능 추가
- 빌드시 생성된 콘솔 로그를 줄 단위로 파싱하여 `List<String>` 형태로 반환

**2. 테스트 방법 (How to Test)**
- 로컬 환경에서 재현 방법:
    1. `GET /build/log?jobName=woojin_test&buildNumber=25` 요청 → 빌드번호 반환
    2. `GET /build/streamlog?jobName=woojin_test` 요청 → 로그 리스트 반환
- 테스트 시나리오:
    - 단위 테스트: REST 응답 파싱 여부 테스트
    - 통합 테스트: 실제 Jenkins 연동 후 정상 응답 여부 확인

**3. 관련 이슈 (Related Issues)**
- 연결된 이슈 번호: `#9`

**4. 체크리스트 (Checklist)**
- [x] 코드 컨벤션을 준수했는가? (파일명, 네이밍, 포맷 등)
- [x] 새로운 기능/버그 수정에 대한 단위 테스트 작성 및 통과했는가?
- [x] 통합 테스트 및 시나리오 테스트를 통과했는가?
- [ ] 문서(Docs) 업데이트가 필요한 경우 반영했는가?
- [x] 주요 로직에 적절한 주석이 포함되었는가?
- [x] 보안/성능 고려 사항 검토했는가?
- [x] 관련 브랜치 전략 및 머지 대상이 적절한가?