### PR TITLE
[docs] 이슈 등록, 완료시 알림

### DIFF
--- a/.github/workflows/notify-discord-on-issue.yml
+++ b/.github/workflows/notify-discord-on-issue.yml
@@ -1,0 +1,27 @@
+name: Notify Discord on Issue Events
+
+on:
+  issues:
+    types: [ opened, labeled ]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Issue Event to Discord
+        run: |
+          if [ "${{ github.event.action }}" = "opened" ]; then
+            MESSAGE="🐛 새 이슈가 등록되었습니다!\n제목: ${{ github.event.issue.title }}\n작성자: ${{ github.actor }}\n링크: ${{ github.event.issue.html_url }}"
+          elif [ "${{ github.event.action }}" = "labeled" ] && [ "${{ github.event.label.name }}" = "done" ]; then
+            MESSAGE="✅ 이슈가 완료되었습니다!\n제목: ${{ github.event.issue.title }}\n처리자: ${{ github.actor }}\n링크: ${{ github.event.issue.html_url }}"
+          else
+            echo "Not an event we're interested in"
+            exit 0
+          fi
+
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "{
+                 \"content\": \"$MESSAGE\"
+               }" \
+               ${{ secrets.ISSUE_WEBHOOK_URL }}


### PR DESCRIPTION
**1. 변경 요약 (Summary of Changes)**
- .github/workflows/notify-discord-on-issue.yml에서 이슈 등록, 완료시에 알림이 오도록 했습니다
