### PR TITLE
[FEAT]: Jenkins 실패 빌드 로그 요약 기능 추가

### DIFF
--- a/backend/src/main/java/com/example/backend/exception/ErrorCode.java
+++ b/backend/src/main/java/com/example/backend/exception/ErrorCode.java
@@ -64,6 +64,9 @@ public enum ErrorCode {
     JENKINS_JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "JENKINS_JOB_NOT_FOUND_404", "해당 Job을 찾을 수 없습니다."),
     JENKINS_BUILD_INFO_MISSING(HttpStatus.BAD_REQUEST, "JENKINS_BUILD_INFO_MISSING_400", "빌드 정보가 존재하지 않습니다."),
     JENKINS_INFO_UNAUTHORIZED(HttpStatus.FORBIDDEN, "JENKINS_INFO_UNAUTHORIZED_403", "접근 권한이 없는 Jenkins 설정입니다."),
+    JENKINS_NO_JOBS_FOUND(HttpStatus.NOT_FOUND, "JENKINS_NO_JOBS_FOUND_404", "등록된 Jenkins Job이 존재하지 않습니다."),
+    JENKINS_ALL_JOBS_FAILED(HttpStatus.BAD_GATEWAY, "JENKINS_ALL_JOBS_FAILED_502", "전체 Job의 빌드 조회에 실패했습니다."),
+
 
 
     /**

--- a/backend/src/main/java/com/example/backend/jenkins/error/client/JenkinsRestClient.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/client/JenkinsRestClient.java
@@ -2,6 +2,7 @@ package com.example.backend.jenkins.error.client;
 
 import com.example.backend.exception.CustomException;
 import com.example.backend.exception.ErrorCode;
+import com.example.backend.service.HttpClientService;
 import org.springframework.http.HttpEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
@@ -10,47 +11,32 @@ import org.springframework.http.*;
 
 public class JenkinsRestClient {
 
-    private final RestTemplate restTemplate;
+    private final HttpClientService httpClientService;
     private final String baseUrl;
     private final String username;
     private final String token;
 
-    public JenkinsRestClient(String baseUrl, String username, String token) {
-        this.restTemplate = new RestTemplate();
+    public JenkinsRestClient(String baseUrl, String username, String token, HttpClientService httpClientService) {
         this.baseUrl = removeTrailingSlash(baseUrl);
         this.username = username;
         this.token = token;
+        this.httpClientService = httpClientService;
     }
 
     public <T> T get(String endpoint, Class<T> responseType) {
-        try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.setBasicAuth(username, token);
-            HttpEntity<?> entity = new HttpEntity<>(headers);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBasicAuth(username, token);
+        HttpEntity<?> entity = new HttpEntity<>(headers);
 
-            String fullUrl = baseUrl + (endpoint.startsWith("/") ? endpoint : "/" + endpoint);
+        String fullUrl = baseUrl + (endpoint.startsWith("/") ? endpoint : "/" + endpoint);
 
-            ResponseEntity<T> response = restTemplate.exchange(fullUrl, HttpMethod.GET, entity, responseType);
-
-            return response.getBody();
-
-        } catch (HttpClientErrorException.NotFound e) {
-            // 404 → Job 없음
-            throw new CustomException(ErrorCode.JENKINS_JOB_NOT_FOUND);
-        } catch (HttpClientErrorException e) {
-            // 401, 403, 400 등 → 클라이언트 오류
-            throw new CustomException(ErrorCode.JENKINS_API_CALL_FAILED);
-        } catch (RestClientException e) {
-            // 커넥션 오류 등
-            throw new CustomException(ErrorCode.JENKINS_API_CALL_FAILED);
-        }
+        return httpClientService.exchange(fullUrl, HttpMethod.GET, entity, responseType);
     }
 
 
     private String removeTrailingSlash(String url) {
         return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
-
     // 실패한 빌드 로그 조회 (Jenkins API)
     public String getConsoleLog(String jobName, int buildNumber) {
         String endpoint = String.format("/job/%s/%d/consoleText", jobName, buildNumber);

--- a/backend/src/main/java/com/example/backend/jenkins/error/client/JenkinsRestClient.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/client/JenkinsRestClient.java
@@ -50,4 +50,10 @@ public class JenkinsRestClient {
     private String removeTrailingSlash(String url) {
         return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
+
+    // 실패한 빌드 로그 조회 (Jenkins API)
+    public String getConsoleLog(String jobName, int buildNumber) {
+        String endpoint = String.format("/job/%s/%d/consoleText", jobName, buildNumber);
+        return get(endpoint, String.class);
+    }
 }

--- a/backend/src/main/java/com/example/backend/jenkins/error/controller/ErrorController.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/controller/ErrorController.java
@@ -10,6 +10,7 @@ import com.example.backend.jenkins.info.model.dto.InfoResponseDto.DetailInfoDto;
 import com.example.backend.jenkins.info.service.JenkinsInfoService;
 import com.example.backend.jenkins.error.client.JenkinsRestClient;
 import com.example.backend.jenkins.error.service.ErrorService;
+import com.example.backend.service.HttpClientService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,6 +25,15 @@ import java.util.List;
 public class ErrorController {
 
     private final ErrorService errorService;
+    private final HttpClientService httpClientService;
+    private JenkinsRestClient buildClient(DetailInfoDto info) {
+        return new JenkinsRestClient(
+                info.getUri(),
+                info.getJenkinsId(),
+                info.getSecretKey(),
+                httpClientService
+        );
+    }
     // 특정 Job의 최근 빌드 1건 조회 API
     @PostMapping("/recent")
     public ResponseEntity<BaseResponse<FailedBuildResDto>> getRecentBuild(
@@ -31,11 +41,7 @@ public class ErrorController {
             @RequestBody JenkinsReqDto request
     ) {
         DetailInfoDto jenkinsInfo = errorService.getDetailInfoByIdAndUser(request.getInfoId(), user.getId());
-        JenkinsRestClient client = new JenkinsRestClient(
-                jenkinsInfo.getUri(),
-                jenkinsInfo.getJenkinsId(),
-                jenkinsInfo.getSecretKey()
-        );
+        JenkinsRestClient client = buildClient(jenkinsInfo);
         FailedBuildResDto build = errorService.getRecentBuild(client, request.getJobName());
         return ResponseEntity.ok(BaseResponse.success(build));
     }
@@ -47,11 +53,7 @@ public class ErrorController {
             @RequestBody JenkinsReqDto request
     ) {
         DetailInfoDto jenkinsInfo = errorService.getDetailInfoByIdAndUser(request.getInfoId(), user.getId());
-        JenkinsRestClient client = new JenkinsRestClient(
-                jenkinsInfo.getUri(),
-                jenkinsInfo.getJenkinsId(),
-                jenkinsInfo.getSecretKey()
-        );
+        JenkinsRestClient client = buildClient(jenkinsInfo);
         List<FailedBuildResDto> builds = errorService.getBuildsForJob(client, request.getJobName());
         return ResponseEntity.ok(BaseResponse.success(builds));
     }
@@ -63,11 +65,7 @@ public class ErrorController {
             @RequestBody JenkinsReqDto request
     ) {
         DetailInfoDto jenkinsInfo = errorService.getDetailInfoByIdAndUser(request.getInfoId(), user.getId());
-        JenkinsRestClient client = new JenkinsRestClient(
-                jenkinsInfo.getUri(),
-                jenkinsInfo.getJenkinsId(),
-                jenkinsInfo.getSecretKey()
-        );
+        JenkinsRestClient client = buildClient(jenkinsInfo);
         List<FailedBuildResDto> builds = errorService.getFailedBuildsForJob(client, request.getJobName());
         return ResponseEntity.ok(BaseResponse.success(builds));
     }
@@ -79,13 +77,7 @@ public class ErrorController {
             @RequestBody JenkinsReqDto request
     ) {
         DetailInfoDto jenkinsInfo = errorService.getDetailInfoByIdAndUser(request.getInfoId(), user.getId());
-
-        JenkinsRestClient client = new JenkinsRestClient(
-                jenkinsInfo.getUri(),
-                jenkinsInfo.getJenkinsId(),
-                jenkinsInfo.getSecretKey()
-        );
-
+        JenkinsRestClient client = buildClient(jenkinsInfo);
         List<FailedBuildResDto> builds = errorService.getRecentBuilds(client);
         return ResponseEntity.ok(BaseResponse.success(builds));
     }
@@ -98,11 +90,7 @@ public class ErrorController {
             @RequestBody JenkinsReqDto request
     ) {
         DetailInfoDto jenkinsInfo = errorService.getDetailInfoByIdAndUser(request.getInfoId(), user.getId());
-        JenkinsRestClient client = new JenkinsRestClient(
-                jenkinsInfo.getUri(),
-                jenkinsInfo.getJenkinsId(),
-                jenkinsInfo.getSecretKey()
-        );
+        JenkinsRestClient client = buildClient(jenkinsInfo);
         List<FailedBuildResDto> builds = errorService.getFailedBuilds(client);
         return ResponseEntity.ok(BaseResponse.success(builds));
     }
@@ -114,11 +102,7 @@ public class ErrorController {
             @RequestBody JenkinsSummaryReqDto request
     ) {
         DetailInfoDto jenkinsInfo = errorService.getDetailInfoByIdAndUser(request.getInfoId(), user.getId());
-        JenkinsRestClient client = new JenkinsRestClient(
-                jenkinsInfo.getUri(),
-                jenkinsInfo.getJenkinsId(),
-                jenkinsInfo.getSecretKey()
-        );
+        JenkinsRestClient client = buildClient(jenkinsInfo);
         FailedBuildSummaryResDto result = errorService.summarizeBuild(client, request.getJobName(), request.getBuildNumber());
         return ResponseEntity.ok(BaseResponse.success(result));
     }

--- a/backend/src/main/java/com/example/backend/jenkins/error/model/dto/FailedBuildSummaryResDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/model/dto/FailedBuildSummaryResDto.java
@@ -1,0 +1,14 @@
+package com.example.backend.jenkins.error.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FailedBuildSummaryResDto {
+    private String jobName;
+    private int buildNumber;
+    private String naturalResponse;  // 자연어 요약 + 해결책 문장
+}

--- a/backend/src/main/java/com/example/backend/jenkins/error/model/dto/JenkinsSummaryReqDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/model/dto/JenkinsSummaryReqDto.java
@@ -1,0 +1,12 @@
+package com.example.backend.jenkins.error.model.dto;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class JenkinsSummaryReqDto {
+    private UUID infoId;
+    private String jobName;
+    private int buildNumber;
+}

--- a/backend/src/main/java/com/example/backend/jenkins/error/service/ErrorService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/service/ErrorService.java
@@ -101,6 +101,10 @@ public class ErrorService {
         Map<?, ?> jobsResponse = client.get("/api/json?tree=jobs[name,url]", Map.class);
         List<Map<String, Object>> jobs = (List<Map<String, Object>>) jobsResponse.get("jobs");
 
+        if (jobs == null || jobs.isEmpty()) {
+            throw new CustomException(ErrorCode.JENKINS_NO_JOBS_FOUND);
+        }
+
         for (Map<String, Object> job : jobs) {
             String jobName = (String) job.get("name");
 
@@ -127,6 +131,10 @@ public class ErrorService {
             }
         }
 
+        if (builds.isEmpty()) {
+            throw new CustomException(ErrorCode.JENKINS_ALL_JOBS_FAILED);
+        }
+
         return builds;
     }
 
@@ -136,6 +144,10 @@ public class ErrorService {
 
         Map<?, ?> jobsResponse = client.get("/api/json?tree=jobs[name]", Map.class);
         List<Map<String, Object>> jobs = (List<Map<String, Object>>) jobsResponse.get("jobs");
+
+        if (jobs == null || jobs.isEmpty()) {
+            throw new CustomException(ErrorCode.JENKINS_NO_JOBS_FOUND);
+        }
 
         for (Map<String, Object> job : jobs) {
             String jobName = (String) job.get("name");
@@ -167,6 +179,10 @@ public class ErrorService {
                 log.warn("Job [{}] 처리 중 예외 발생 → {}: {}", jobName, e.getErrorCode().name(), e.getMessage());
                 continue;
             }
+        }
+
+        if (builds.isEmpty()) {
+            throw new CustomException(ErrorCode.JENKINS_ALL_JOBS_FAILED);
         }
 
         return builds;

--- a/backend/src/main/java/com/example/backend/jenkins/error/service/ErrorService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/service/ErrorService.java
@@ -103,7 +103,8 @@ public class ErrorService {
         List<Map<String, Object>> jobs = (List<Map<String, Object>>) jobsResponse.get("jobs");
 
         if (jobs == null || jobs.isEmpty()) {
-            throw new CustomException(ErrorCode.JENKINS_NO_JOBS_FOUND);
+            log.warn("Jenkins 서버에 등록된 Job이 없습니다.");
+            return builds;
         }
 
         for (Map<String, Object> job : jobs) {
@@ -130,10 +131,6 @@ public class ErrorService {
                 log.warn("Job [{}] 처리 중 예외 발생 → {}: {}", jobName, e.getErrorCode().name(), e.getMessage());
                 continue;
             }
-        }
-
-        if (builds.isEmpty()) {
-            throw new CustomException(ErrorCode.JENKINS_ALL_JOBS_FAILED);
         }
 
         return builds;
@@ -180,10 +177,6 @@ public class ErrorService {
                 log.warn("Job [{}] 처리 중 예외 발생 → {}: {}", jobName, e.getErrorCode().name(), e.getMessage());
                 continue;
             }
-        }
-
-        if (builds.isEmpty()) {
-            throw new CustomException(ErrorCode.JENKINS_ALL_JOBS_FAILED);
         }
 
         return builds;

--- a/backend/src/main/java/com/example/backend/jenkins/error/service/ErrorService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/service/ErrorService.java
@@ -4,8 +4,7 @@ import com.example.backend.exception.CustomException;
 import com.example.backend.exception.ErrorCode;
 import com.example.backend.jenkins.error.client.JenkinsRestClient;
 import com.example.backend.jenkins.error.model.dto.FailedBuildResDto;
-import com.example.backend.jenkins.error.client.JenkinsRestClient;
-import com.example.backend.jenkins.error.model.dto.FailedBuildResDto;
+import com.example.backend.jenkins.error.model.dto.FailedBuildSummaryResDto;
 import com.example.backend.jenkins.info.model.JenkinsInfo;
 import com.example.backend.jenkins.info.model.dto.InfoResponseDto;
 import com.example.backend.jenkins.info.repository.JenkinsInfoRepository;
@@ -14,12 +13,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+
 import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class ErrorService {
     private final JenkinsInfoRepository jenkinsInfoRepository;
+    private final LlmService llmService;
     private static final Logger log = LoggerFactory.getLogger(ErrorService.class);
 
     // 특정 Job의 최근 빌드 1건 조회
@@ -194,6 +195,27 @@ public class ErrorService {
                 .orElseThrow(() -> new CustomException(ErrorCode.JENKINS_INFO_NOT_FOUND));
 
         return InfoResponseDto.DetailInfoDto.fromEntity(info);
+    }
+
+    public FailedBuildSummaryResDto summarizeBuild(JenkinsRestClient client, String jobName, int buildNumber) {
+        String log = client.getConsoleLog(jobName, buildNumber);
+
+        // 에러가 없어 보이면 바로 응답
+        if (!log.contains("Exception") && !log.contains("FAILURE") && !log.contains("Caused by")) {
+            return FailedBuildSummaryResDto.builder()
+                    .jobName(jobName)
+                    .buildNumber(buildNumber)
+                    .naturalResponse("이 빌드는 에러 없이 정상적으로 완료된 것으로 보입니다.")
+                    .build();
+        }
+
+        String response = llmService.summarizeBuildLog(log);
+
+        return FailedBuildSummaryResDto.builder()
+                .jobName(jobName)
+                .buildNumber(buildNumber)
+                .naturalResponse(response)
+                .build();
     }
 
 

--- a/backend/src/main/java/com/example/backend/jenkins/error/service/LlmService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/service/LlmService.java
@@ -1,0 +1,64 @@
+package com.example.backend.jenkins.error.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class LlmService {
+
+    @Value("${openai.api-key}")
+    private String apiKey;
+
+    /**
+     * Jenkins 빌드 로그를 요약하기 위한 메인 메서드.
+     * 로그 문자열을 받아서 LLM에게 전달하고 응답을 반환.
+     */
+    public String summarizeBuildLog(String log) {
+        String prompt = buildPrompt(log);
+        return callOpenAi(prompt);
+    }
+
+    /**
+     * 전달받은 Jenkins 로그를 기반으로 LLM에 보낼 프롬프트 텍스트 생성
+     */
+    private String buildPrompt(String log) {
+        return "다음은 Jenkins 빌드 로그입니다. 실패 원인을 요약하고 해결책을 제시해주세요:\n\n" + log;
+    }
+
+    /**
+     * OpenAI Chat Completions API를 호출하여 요약 응답을 받는 메서드
+     */
+    private String callOpenAi(String prompt) {
+        // 예시: 실제 OpenAI API 호출
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey); // API 키
+
+        Map<String, Object> body = Map.of(
+                "model", "gpt-4", // 사용할 모델
+                "messages", List.of(
+                        Map.of("role", "user", "content", prompt)
+                )
+        );
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+        ResponseEntity<Map> response = new RestTemplate().postForEntity(
+                "https://api.openai.com/v1/chat/completions",
+                request,
+                Map.class
+        );
+
+        // 응답에서 실제 메시지 추출
+        return ((Map)((List)response.getBody().get("choices")).get(0)).get("message").toString();
+    }
+}
+
+

--- a/backend/src/main/java/com/example/backend/jenkins/error/service/LlmService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/service/LlmService.java
@@ -37,6 +37,7 @@ public class LlmService {
      * OpenAI Chat Completions API를 호출하여 요약 응답을 받는 메서드
      */
     private String callOpenAi(String prompt) {
+
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth(apiKey); // API 키

--- a/backend/src/main/java/com/example/backend/jenkins/error/service/LlmService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/service/LlmService.java
@@ -37,13 +37,12 @@ public class LlmService {
      * OpenAI Chat Completions API를 호출하여 요약 응답을 받는 메서드
      */
     private String callOpenAi(String prompt) {
-        // 예시: 실제 OpenAI API 호출
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth(apiKey); // API 키
 
         Map<String, Object> body = Map.of(
-                "model", "gpt-4", // 사용할 모델
+                "model", "gpt-4o-mini", // 사용할 모델
                 "messages", List.of(
                         Map.of("role", "user", "content", prompt)
                 )

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -78,5 +78,5 @@ app:
     url: ${VERIFY_URL}
 
 encryption:
-  key: ${ENCRYPTION_KEY}
+  key: ${ENCRYPTION_KEY}보
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -78,5 +78,5 @@ app:
     url: ${VERIFY_URL}
 
 encryption:
-  key: ${ENCRYPTION_KEY}보
+  key: ${ENCRYPTION_KEY}
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -80,3 +80,6 @@ app:
 encryption:
   key: ${ENCRYPTION_KEY}
 
+openai:
+  api-key: ${OPENAI_API_KEY}
+


### PR DESCRIPTION
**1. 변경 요약 (Summary of Changes)**
- Jenkins 실패 빌드 요약 기능 추가
- 사용자의 Jenkins Info를 바탕으로 인증된 Jenkins API 호출
- 실패한 빌드 로그를 GPT-4o-mini에 전달하여 자연어로 요약 및 해결 방안 생성
- `/api/jenkins-error/summary` 엔드포인트 구현
- `LlmService`를 통해 OpenAI API 호출
- `FailedBuildSummaryResDto` 형태로 요약 응답 반환

**2. 테스트 방법 (How to Test)**
- 로컬 환경에서 재현 방법:
    1. 유효한 JWT 토큰으로 Postman 실행
    2. 실패한 빌드 로그가 있는 Jenkins Job을 등록
    3. `/api/jenkins-error/summary`에 요청 전송

- 테스트 시나리오:
    - 단위 테스트: postman으로 각 endpoint 정상 작동 확인

**3. 관련 이슈 (Related Issues)**
- 연결된 이슈 번호: #59 

**4. 체크리스트 (Checklist)**
- [x] 코드 컨벤션을 준수했는가? (파일명, 네이밍, 포맷 등)
- [x] 새로운 기능/버그 수정에 대한 단위 테스트 작성 및 통과했는가?
- [x] 통합 테스트 및 시나리오 테스트를 통과했는가?
- [ ] 문서(Docs) 업데이트가 필요한 경우 반영했는가?
- [x] 주요 로직에 적절한 주석이 포함되었는가?
- [x] 보안/성능 고려 사항 검토했는가?
- [x] 관련 브랜치 전략 및 머지 대상이 적절한가?
