### PR TITLE
[FEAT] ErrorController 테스트 코드 추가

### DIFF
--- a/backend/src/main/java/com/example/backend/jenkins/error/model/dto/JobReqDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/model/dto/JobReqDto.java
@@ -1,10 +1,16 @@
 package com.example.backend.jenkins.error.model.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class JobReqDto {
     private UUID jobId; // 지금은 프리스타일 job id
     private String jobName;

--- a/backend/src/main/java/com/example/backend/jenkins/error/model/dto/JobSummaryReqDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/model/dto/JobSummaryReqDto.java
@@ -1,10 +1,12 @@
 package com.example.backend.jenkins.error.model.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.UUID;
 
 @Getter
+@Builder
 public class JobSummaryReqDto {
     private UUID jobId;
     private int buildNumber;;

--- a/backend/src/main/java/com/example/backend/jenkins/error/model/dto/RetryReqDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/model/dto/RetryReqDto.java
@@ -1,10 +1,16 @@
 package com.example.backend.jenkins.error.model.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class RetryReqDto {
     private UUID jobId;
 }

--- a/backend/src/main/java/com/example/backend/jenkins/error/service/ErrorService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/service/ErrorService.java
@@ -287,7 +287,7 @@ public class ErrorService {
         httpClientService.exchange(triggerUrl, HttpMethod.POST, entity, String.class);
     }
 
-    private String extractVersionFromLog(String buildLog) {
+    String extractVersionFromLog(String buildLog) {
         for (String line : buildLog.split("\n")) {
             String trimmed = line.trim();
             int idx = trimmed.indexOf("#VERSION:");
@@ -297,7 +297,7 @@ public class ErrorService {
                 if (parts.length > 1) {
                     String version = parts[1].trim();
                     log.info("[버전 추출] 추출된 VERSION: {}", version); // 이제 정상 작동
-                    return version;
+                    return version.replaceAll("\"", "").trim();
                 }
             }
         }

--- a/backend/src/main/java/com/example/backend/jenkins/error/service/LlmService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/error/service/LlmService.java
@@ -1,5 +1,7 @@
 package com.example.backend.jenkins.error.service;
 
+import com.example.backend.service.HttpClientService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
@@ -12,7 +14,10 @@ import java.util.List;
 import java.util.Map;
 
 @Service
+@RequiredArgsConstructor
 public class LlmService {
+
+    private final HttpClientService httpClientService;
 
     @Value("${openai.api-key}")
     private String apiKey;
@@ -49,14 +54,15 @@ public class LlmService {
         );
 
         HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
-        ResponseEntity<Map> response = new RestTemplate().postForEntity(
+        Map response = httpClientService.exchange(
                 "https://api.openai.com/v1/chat/completions",
+                HttpMethod.POST,
                 request,
                 Map.class
         );
 
         // 응답에서 실제 메시지 추출
-        return ((Map)((List)response.getBody().get("choices")).get(0)).get("message").toString();
+        return ((Map)((List)response.get("choices")).get(0)).get("message").toString();
     }
 }
 

--- a/backend/src/test/java/com/example/backend/jenkins/error/controller/ErrorControllerTest.java
+++ b/backend/src/test/java/com/example/backend/jenkins/error/controller/ErrorControllerTest.java
@@ -1,0 +1,206 @@
+package com.example.backend.jenkins.error.controller;
+
+import com.example.backend.auth.user.model.Users;
+import com.example.backend.config.jwt.JwtAuthenticationFilter;
+import com.example.backend.config.jwt.JwtTokenProvider;
+import com.example.backend.jenkins.error.model.dto.*;
+import com.example.backend.jenkins.error.service.ErrorService;
+import com.example.backend.jenkins.job.repository.FreeStyleRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ErrorController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                OAuth2ClientAutoConfiguration.class,
+                OAuth2ResourceServerAutoConfiguration.class
+        }
+)
+@AutoConfigureMockMvc(addFilters = false)
+class ErrorControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean
+    ErrorService errorService;
+    @MockitoBean private FreeStyleRepository freeStyleRepository;
+    @MockitoBean private JwtAuthenticationFilter jwtAuthenticationFilter; // 필요 시
+    @MockitoBean private JwtTokenProvider jwtTokenProvider;
+
+    Users testUser;
+    UUID jobId = UUID.randomUUID();
+    UUID infoId = UUID.randomUUID();
+
+    @BeforeEach
+    void setup() {
+        testUser = Users.builder().id(UUID.randomUUID()).build();
+    }
+
+    @Test
+    @DisplayName("최근 빌드 1건 조회")
+    void getRecentBuildTest() throws Exception {
+        FailedBuildResDto mockRes = FailedBuildResDto.of("JobA", 1, "FAILURE", 1000L, 100L);
+        when(errorService.getRecentBuildByJob(eq(jobId), any())).thenReturn(mockRes);
+
+        JobReqDto reqDto = new JobReqDto(jobId, "JobA");
+
+        mockMvc.perform(post("/api/jenkins-error/recent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reqDto))
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(testUser, null)))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.jobName").value("JobA"));
+    }
+
+    @Test
+    @DisplayName("전체 빌드 조회")
+    void getBuildsByJobTest() throws Exception {
+        when(errorService.getBuildsForJobByUser(eq(jobId), any()))
+                .thenReturn(List.of(FailedBuildResDto.of("JobA", 1, "FAILURE", 1000L, 100L)));
+
+        JobReqDto reqDto = new JobReqDto(jobId, "JobA");
+
+        mockMvc.perform(post("/api/jenkins-error/history")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reqDto))
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(testUser, null)))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].jobName").value("JobA"));
+    }
+
+    @Test
+    @DisplayName("실패한 빌드만 조회")
+    void getFailedBuildsByJobTest() throws Exception {
+        when(errorService.getFailedBuildsForJobByUser(eq(jobId), any()))
+                .thenReturn(List.of(FailedBuildResDto.of("JobA", 2, "FAILURE", 2000L, 200L)));
+
+        JobReqDto reqDto = new JobReqDto(jobId, "JobA");
+
+        mockMvc.perform(post("/api/jenkins-error/history/failed")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reqDto))
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(testUser, null)))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].buildNumber").value(2));
+    }
+
+    @Test
+    @DisplayName("전체 최근 빌드 조회")
+    void getAllRecentBuildsTest() throws Exception {
+        when(errorService.getJenkinsInfoByIdAndUser(eq(infoId), any())).thenReturn(null);
+        when(errorService.getRecentBuilds(any())).thenReturn(List.of());
+
+        JenkinsReqDto reqDto = new JenkinsReqDto(infoId, "JobA");
+
+        mockMvc.perform(post("/api/jenkins-error/recent/all")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reqDto))
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(testUser, null)))
+                )
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("전체 실패 빌드 조회")
+    void getFailedBuildsTest() throws Exception {
+        when(errorService.getJenkinsInfoByIdAndUser(eq(infoId), any())).thenReturn(null);
+        when(errorService.getFailedBuilds(any())).thenReturn(List.of());
+
+        JenkinsReqDto reqDto = new JenkinsReqDto(infoId, "JobA");
+
+        mockMvc.perform(post("/api/jenkins-error/failed/all")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reqDto))
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(testUser, null)))
+                )
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("GPT 빌드 요약 응답")
+    void getBuildSummaryWithSolutionTest() throws Exception {
+        when(errorService.summarizeBuildByJob(any(), any()))
+                .thenReturn(FailedBuildSummaryResDto.builder()
+                        .jobName("JobA")
+                        .buildNumber(1)
+                        .naturalResponse("에러는 ~ 때문입니다")
+                        .build());
+
+        JobSummaryReqDto reqDto = JobSummaryReqDto.builder().jobId(jobId).buildNumber(1).build();
+
+        mockMvc.perform(post("/api/jenkins-error/summary")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reqDto))
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(testUser, null)))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.naturalResponse").value("에러는 ~ 때문입니다"));
+    }
+
+    @Test
+    @DisplayName("FreeStyle 리트라이")
+    void retryWithRollbackTest() throws Exception {
+        doNothing().when(errorService).retryWithRollback(eq(jobId), any());
+
+        RetryReqDto reqDto = new RetryReqDto(jobId);
+
+        mockMvc.perform(post("/api/jenkins-error/retry")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reqDto))
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(testUser, null)))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("Retry with rollback triggered."));
+    }
+
+    @Test
+    @DisplayName("Pipeline 리트라이")
+    void retryWithRollbackByPipelineTest() throws Exception {
+        doNothing().when(errorService).retryWithRollbackByPipeline(eq(jobId), any());
+
+        RetryReqDto reqDto = new RetryReqDto(jobId);
+
+        mockMvc.perform(post("/api/jenkins-error/retry/pipeline")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reqDto))
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(testUser, null)))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("Retry with rollback triggered."));
+    }
+}

--- a/backend/src/test/java/com/example/backend/jenkins/error/service/ErrorServiceTest.java
+++ b/backend/src/test/java/com/example/backend/jenkins/error/service/ErrorServiceTest.java
@@ -1,0 +1,153 @@
+package com.example.backend.jenkins.error.service;
+
+import com.example.backend.exception.CustomException;
+import com.example.backend.exception.ErrorCode;
+import com.example.backend.jenkins.error.model.dto.FailedBuildResDto;
+import com.example.backend.jenkins.error.model.dto.FailedBuildSummaryResDto;
+import com.example.backend.jenkins.error.model.dto.JobSummaryReqDto;
+import com.example.backend.jenkins.info.model.JenkinsInfo;
+import com.example.backend.jenkins.info.repository.JenkinsInfoRepository;
+import com.example.backend.jenkins.job.model.FreeStyle;
+import com.example.backend.jenkins.job.model.FreeStyleHistory;
+import com.example.backend.jenkins.job.repository.FreeStyleHistoryRepository;
+import com.example.backend.jenkins.job.repository.PipelineHistoryRepository;
+import com.example.backend.jenkins.job.repository.PipelineRepository;
+import com.example.backend.jenkins.job.service.FreeStyleJobService;
+import com.example.backend.jenkins.job.service.PipelineJobService;
+import com.example.backend.service.HttpClientService;
+import com.example.backend.auth.user.model.Users;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ErrorServiceTest {
+
+    @InjectMocks
+    private ErrorService errorService;
+
+    @Mock private JenkinsInfoRepository jenkinsInfoRepository;
+    @Mock private FreeStyleJobService freeStyleJobService;
+    @Mock private FreeStyleHistoryRepository freeStyleHistoryRepository;
+    @Mock private PipelineHistoryRepository pipelineHistoryRepository;
+    @Mock private PipelineRepository pipelineRepository;
+    @Mock private PipelineJobService pipelineJobService;
+    @Mock private HttpClientService httpClientService;
+    @Mock private LlmService llmService;
+
+    private UUID userId;
+    private UUID jobId;
+    private JenkinsInfo mockInfo;
+    private FreeStyle mockJob;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        jobId = UUID.randomUUID();
+        Users user = Users.builder().id(userId).build();
+        mockInfo = JenkinsInfo.builder().uri("http://jenkins.local").user(user).build();
+        mockJob = FreeStyle.builder().id(jobId).jobName("test-job").jenkinsInfo(mockInfo).build();
+    }
+
+    @Test
+    @DisplayName("getVerifiedJob - 소유자이면 정상 반환")
+    void getVerifiedJob_success() {
+        when(freeStyleJobService.getFreeStyleById(jobId)).thenReturn(mockJob);
+        FreeStyle result = errorService.getVerifiedJob(jobId, userId);
+        assertEquals(mockJob, result);
+    }
+
+    @Test
+    @DisplayName("getVerifiedJob - 소유자 아님이면 예외 발생")
+    void getVerifiedJob_unauthorized() {
+        Users otherUser = Users.builder().id(UUID.randomUUID()).build();
+        JenkinsInfo otherInfo = JenkinsInfo.builder().user(otherUser).build();
+        FreeStyle job = FreeStyle.builder().jenkinsInfo(otherInfo).build();
+
+        when(freeStyleJobService.getFreeStyleById(jobId)).thenReturn(job);
+
+        assertThrows(CustomException.class, () -> errorService.getVerifiedJob(jobId, userId));
+    }
+
+    @Test
+    @DisplayName("getRecentBuild - 정상 Jenkins 응답이면 DTO 반환")
+    void getRecentBuild_success() {
+        Map<String, Object> mockResponse = Map.of(
+                "number", 10,
+                "result", "FAILURE",
+                "timestamp", 1000L,
+                "duration", 3000L
+        );
+
+        when(httpClientService.buildHeaders(mockInfo, MediaType.APPLICATION_JSON)).thenReturn(new HttpHeaders());
+        when(httpClientService.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(mockResponse);
+
+        FailedBuildResDto result = errorService.getRecentBuild(mockInfo, "test-job");
+
+        assertEquals("FAILURE", result.getResult());
+        assertEquals(10, result.getBuildNumber());
+    }
+
+    @Test
+    @DisplayName("summarizeBuild - 예외 로그 포함 시 LLM 호출")
+    void summarizeBuild_failureLog() {
+        String buildLog = "Exception in thread main";
+        when(httpClientService.buildHeaders(mockInfo, MediaType.TEXT_PLAIN)).thenReturn(new HttpHeaders());
+        when(httpClientService.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(buildLog);
+        when(llmService.summarizeBuildLog(anyString())).thenReturn("에러는 ~ 때문입니다.");
+
+        FailedBuildSummaryResDto result = errorService.summarizeBuild(mockInfo, "test-job", 11);
+
+        assertEquals("에러는 ~ 때문입니다.", result.getNaturalResponse());
+        assertEquals("test-job", result.getJobName());
+    }
+
+    @Test
+    @DisplayName("summarizeBuild - 예외 없는 로그는 고정 응답")
+    void summarizeBuild_successLog() {
+        String log = "빌드 성공!";
+        when(httpClientService.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(log);
+        when(httpClientService.buildHeaders(any(), eq(MediaType.TEXT_PLAIN))).thenReturn(new HttpHeaders());
+
+        FailedBuildSummaryResDto result = errorService.summarizeBuild(mockInfo, "jobA", 2);
+
+        assertTrue(result.getNaturalResponse().contains("정상적으로 완료"));
+    }
+
+    @Test
+    @DisplayName("extractVersionFromLog - 정상 추출")
+    void extractVersionFromLog() {
+        String log = """
+                + echo "#VERSION: 2"
+                #VERSION: 2
+                """;
+
+        String version = errorService.extractVersionFromLog(log);
+
+        assertEquals("2", version);
+    }
+
+    @Test
+    @DisplayName("extractVersionFromLog - 없으면 null 반환")
+    void extractVersionFromLog_missing() {
+        String log = "성공적인 로그입니다";
+        String version = errorService.extractVersionFromLog(log);
+        assertNull(version);
+    }
+}

--- a/backend/src/test/java/com/example/backend/jenkins/error/service/LlmServiceTest.java
+++ b/backend/src/test/java/com/example/backend/jenkins/error/service/LlmServiceTest.java
@@ -1,0 +1,59 @@
+package com.example.backend.jenkins.error.service;
+
+import com.example.backend.service.HttpClientService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LlmServiceTest {
+
+    @InjectMocks
+    private LlmService llmService;
+
+    @Mock
+    private HttpClientService httpClientService;
+
+    @BeforeEach
+    void setUp() {
+        org.springframework.test.util.ReflectionTestUtils.setField(llmService, "apiKey", "test-api-key");
+    }
+
+    @Test
+    @DisplayName("summarizeBuildLog - 정상 응답 시 메시지 추출됨")
+    void summarizeBuildLog_success() {
+        // given
+        String mockLog = "Exception in thread main: NullPointerException";
+
+        // mock OpenAI 응답 구조
+        Map<String, Object> openAiResponse = Map.of(
+                "choices", List.of(
+                        Map.of("message", Map.of("role", "assistant", "content", "NullPointer 발생입니다."))
+                )
+        );
+
+        when(httpClientService.exchange(
+                eq("https://api.openai.com/v1/chat/completions"),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(Map.class)
+        )).thenReturn(openAiResponse);
+
+        // when
+        String result = llmService.summarizeBuildLog(mockLog);
+
+        // then
+        assertTrue(result.contains("content=NullPointer 발생입니다."));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #60 

## 📝작업 내용

> - `ErrorController` 전체 API에 대한 단위 테스트 코드 작성
>- 테스트 수행을 위한 DTO에 `@Builder`, `@AllArgsConstructor`, `@NoArgsConstructor` 등 추가
>- `ErrorService`, `LlmService`에 대해 단위 테스트 코드 작성
>- `LlmService`는 `RestTemplate` 직접 생성 방식 제거


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


**체크리스트**

- [x] 코드 컨벤션을 준수했는가? (파일명, 네이밍, 포맷 등)
- [x] 새로운 기능/버그 수정에 대한 단위 테스트 작성 및 통과했는가?
- [x] 통합 테스트 및 시나리오 테스트를 통과했는가?
- [ ] 문서(Docs) 업데이트가 필요한 경우 반영했는가?
- [x] 주요 로직에 적절한 주석이 포함되었는가?
- [x] 보안/성능 고려 사항 검토했는가?
- [x] 관련 브랜치 전략 및 머지 대상이 적절한가?
