### PR TITLE
[FEAT] Job 상세조회, 스케줄링

### DIFF
--- a/backend/src/main/java/com/example/backend/jenkins/job/controller/JobController.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/controller/JobController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
-@Tag(name = "FreeStyle Job API", description = "Jenkins Freestyle 잡 생성, 수정, 삭제 및 이력 조회 API")
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/jenkins/job")
@@ -128,80 +127,4 @@ public class JobController {
                 .body(BaseResponse.success(pipelineService.getDeletedLightJobs(jenkinsInfoId)));
     }
 
-    @PostMapping("/generate/script")
-    public ResponseEntity<BaseResponse<ResponseDto.LightScriptDto>> generateScript(
-            @RequestBody @Valid RequestDto.ScriptBaseDto requestDto
-    ) {
-        return ResponseEntity.ok()
-                .body(BaseResponse.success(pipelineService.generateScript(requestDto)));
-    }
-   /* @GetMapping
-    public ResponseEntity<BaseResponse<List<LightFreeStyleDto>>> getAllFreeStyle(
-            @Parameter(description = "JenkinsInfo의 UUID", required = true)
-            @RequestParam UUID infoId
-    ) {
-        return ResponseEntity.ok()
-                .body(BaseResponse.success(freeStyleJobService.getAllLightFreeStyle(infoId)));
-    }
-
-    @PostMapping("/{id}")
-    public ResponseEntity<BaseResponse<DetailFreeStyleDto>> getFreeStyleById(
-            @PathVariable UUID id
-    ) {
-        return ResponseEntity.ok()
-                .body(BaseResponse.success(freeStyleJobService.getDetailFreeStyleById(id)));
-    }
-
-    @Operation(
-            summary = "Freestyle 잡 이력 목록 조회",
-            description = "지정된 FreeStyle 잡의 이력 목록(LightHistoryDto)을 반환합니다."
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "FreeStyle 이력 목록 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "잘못된 FreeStyle Id")
-    })
-    @GetMapping("/freeStyle/history")
-    public ResponseEntity<BaseResponse<List<LightHistoryDto>>> getFreeStyleHistory(
-            @Parameter(description = "조회할 FreeStyle 잡의 UUID", required = true)
-            @RequestParam UUID id
-    ) {
-        return ResponseEntity.ok()
-                .body(BaseResponse.success(freeStyleJobService.getLightHistory(id)));
-    }
-
-    @Operation(
-            summary = "단일 FreeStyle 이력 상세 조회",
-            description = "이력 ID를 통해 해당 FreeStyleHistory의 상세 정보를 반환합니다."
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "단일 FreeStyleHistory 상세 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "잘못된 FreeStyleHistory Id")
-    })
-    @GetMapping("/freeStyle/history/{id}")
-    public ResponseEntity<BaseResponse<DetailHistoryDto>> getFreeStyleHistoryById(
-            @Parameter(description = "조회할 FreeStyleHistory의 UUID", required = true)
-            @PathVariable UUID id
-    ) {
-        return ResponseEntity.ok()
-                .body(BaseResponse.success(freeStyleJobService.getFreeStyleHistoryById(id)));
-    }
-
-    @Operation(
-            summary = "Freestyle 잡 롤백",
-            description = "지정된 이력 ID를 기반으로 Freestyle 잡을 해당 버전으로 롤백합니다."
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "단일 FreeStyleHistory 상세 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "잘못된 FreeStyleHistory Id 또는 연결 실패"),
-            @ApiResponse(responseCode = "500", description = "Jenkins 서버 문제로 인한 실패")
-    })
-    @GetMapping("/freeStyle/rollBack")
-    public ResponseEntity<BaseResponse<String>> rollBack(
-            @Parameter(description = "롤백할 FreeStyleHistory의 UUID", required = true)
-            @RequestParam UUID id
-    ) {
-        freeStyleJobService.rollBack(id);
-        return ResponseEntity.ok()
-                .body(BaseResponse.success("roll back success"));
-    }*/
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/controller/ScriptController.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/controller/ScriptController.java
@@ -7,10 +7,9 @@ import com.example.backend.jenkins.job.service.ScriptService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,5 +26,13 @@ public class ScriptController {
                 .body(BaseResponse.success(scriptService.generateScript(requestDto)));
     }
 
+    @DeleteMapping
+    public ResponseEntity<BaseResponse<String>> deleteScript(
+            @RequestParam UUID scriptId
+    ) {
+        scriptService.deleteScript(scriptId);
 
+        return ResponseEntity.ok()
+                .body(BaseResponse.success("Script deleted success"));
+    }
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/controller/ScriptController.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/controller/ScriptController.java
@@ -1,0 +1,29 @@
+package com.example.backend.jenkins.job.controller;
+
+import com.example.backend.exception.BaseResponse;
+import com.example.backend.jenkins.job.model.dto.RequestDto;
+import com.example.backend.jenkins.job.model.dto.ResponseDto;
+import com.example.backend.jenkins.job.service.ScriptService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/jenkins/job/script")
+public class ScriptController {
+
+    private final ScriptService scriptService;
+
+    @PostMapping("/generate/script")
+    public ResponseEntity<BaseResponse<ResponseDto.LightScriptDto>> generateScript(
+            @RequestBody @Valid RequestDto.ScriptBaseDto requestDto
+    ) {
+        return ResponseEntity.ok()
+                .body(BaseResponse.success(scriptService.generateScript(requestDto)));
+    }
+}

--- a/backend/src/main/java/com/example/backend/jenkins/job/controller/ScriptController.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/controller/ScriptController.java
@@ -19,11 +19,13 @@ public class ScriptController {
 
     private final ScriptService scriptService;
 
-    @PostMapping("/generate/script")
+    @PostMapping("/generate")
     public ResponseEntity<BaseResponse<ResponseDto.LightScriptDto>> generateScript(
             @RequestBody @Valid RequestDto.ScriptBaseDto requestDto
     ) {
         return ResponseEntity.ok()
                 .body(BaseResponse.success(scriptService.generateScript(requestDto)));
     }
+
+
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/Pipeline.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/Pipeline.java
@@ -36,7 +36,7 @@ public class Pipeline {
     private Boolean isTriggered;
 
     // 스케줄 설정
-    private String cronExpression;
+    private String schedule;
 
     // 삭제 여부
     private Boolean isDeleted;

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/Pipeline.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/Pipeline.java
@@ -35,6 +35,9 @@ public class Pipeline {
     // git webhook trigger 설정 여부
     private Boolean isTriggered;
 
+    // 스케줄 설정
+    private String cronExpression;
+
     // 삭제 여부
     private Boolean isDeleted;
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/Script.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/Script.java
@@ -36,6 +36,21 @@ public class Script {
     // Test Stage가 선택되었는지 여부
     private Boolean isTestSelected;
 
+    private Boolean isK8sDeploy;
+    private String tag;
+    private String sshKeyPath;
+    private String sshPort;
+    private String deployTarget;
+    private String k8sPath;
+    private String deploymentName;
+    private String namespace;
+    private String appName;
+    private String containerName;
+    private String imageRepo;
+    private String port;
+    private String springProfile;
+    private String replicas;
+
     @Lob
     private String script;
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/dto/RequestDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/dto/RequestDto.java
@@ -19,6 +19,7 @@ public class RequestDto {
                 .name(requestDto.getName())
                 .description(requestDto.getDescription())
                 .trigger(requestDto.getTrigger())
+                .schedule(requestDto.getSchedule())
                 .build();
     }
 
@@ -28,6 +29,7 @@ public class RequestDto {
                 .name(requestDto.getName())
                 .description(requestDto.getDescription())
                 .isTriggered(requestDto.getTrigger())
+                .schedule(requestDto.getSchedule())
                 .jenkinsInfo(info)
                 .createdAt(LocalDateTime.now())
                 .isDeleted(false)
@@ -83,6 +85,9 @@ public class RequestDto {
 
         // git webhook trigger 설정 여부
         private Boolean trigger;
+
+        // 스케줄 설정
+        private String schedule;
     }
 
 
@@ -104,5 +109,7 @@ public class RequestDto {
         // git webhook trigger 설정 여부
         private Boolean trigger;
 
+        // 스케줄 설정
+        private String schedule;
     }
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
@@ -21,6 +21,7 @@ public class ResponseDto {
     }
 
     public static DetailJobDto entityToDetailJobDto(Pipeline pipeline) {
+        Script script = pipeline.getScript();
         return DetailJobDto.builder()
                 .pipelineId(pipeline.getId())
                 .name(pipeline.getName())
@@ -29,12 +30,31 @@ public class ResponseDto {
                 .createdAt(pipeline.getCreatedAt())
                 .updatedAt(pipeline.getUpdatedAt())
                 .deletedAt(pipeline.getDeletedAt())
+                .lightScriptDto(entityToLightScriptDto(script))
                 .build();
     }
 
     public static LightScriptDto entityToLightScriptDto(Script script) {
         return LightScriptDto.builder()
                 .scriptId(script.getId())
+                .githubUrl(script.getGithubUrl())
+                .branch(script.getBranch())
+                .isBuildSelected(script.getIsBuildSelected())
+                .isTestSelected(script.getIsTestSelected())
+                .isK8sDeploy(script.getIsK8sDeploy())
+                .tag(script.getTag())
+                .sshKeyPath(script.getSshKeyPath())
+                .sshPort(script.getSshPort())
+                .deployTarget(script.getDeployTarget())
+                .k8sPath(script.getK8sPath())
+                .deploymentName(script.getDeploymentName())
+                .namespace(script.getNamespace())
+                .appName(script.getAppName())
+                .containerName(script.getContainerName())
+                .imageRepo(script.getImageRepo())
+                .port(script.getPort())
+                .springProfile(script.getSpringProfile())
+                .replicas(script.getReplicas())
                 .script(script.getScript())
                 .build();
     }
@@ -60,37 +80,27 @@ public class ResponseDto {
     @AllArgsConstructor
     public static class DetailJobDto {
 
+        LightScriptDto lightScriptDto;
         private UUID pipelineId;
-
         // job 이름
         private String name;
-
         // job 설명
         private String description;
-
         // 연동된 git 주소
         private String githubUrl;
-
         // clone할 branch 이름
         private String branch;
-
         // git webhook trigger 설정 여부
         private Boolean trigger;
-
         // Build Stage가 선택되었는지 여부
         private Boolean isBuildSelected;
-
         // Test Stage가 선택되었는지 여부
         private Boolean isTestSelected;
-
         // 생성 시간
         private LocalDateTime createdAt;
-
         // 수정 시간
         private LocalDateTime updatedAt;
-
         private LocalDateTime deletedAt;
-
         private String script;
     }
 
@@ -101,6 +111,32 @@ public class ResponseDto {
     public static class LightScriptDto {
 
         private UUID scriptId;
+        // 연동된 git 주소
+        private String githubUrl;
+
+        // clone할 branch 이름
+        private String branch;
+
+        // Build Stage가 선택되었는지 여부
+        private Boolean isBuildSelected;
+
+        // Test Stage가 선택되었는지 여부
+        private Boolean isTestSelected;
+
+        private Boolean isK8sDeploy;
+        private String tag;
+        private String sshKeyPath;
+        private String sshPort;
+        private String deployTarget;
+        private String k8sPath;
+        private String deploymentName;
+        private String namespace;
+        private String appName;
+        private String containerName;
+        private String imageRepo;
+        private String port;
+        private String springProfile;
+        private String replicas;
 
         private String script;
     }

--- a/backend/src/main/java/com/example/backend/jenkins/job/repository/PipelineRepository.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/repository/PipelineRepository.java
@@ -15,6 +15,7 @@ public interface PipelineRepository extends JpaRepository<Pipeline, UUID> {
             SELECT pl
                 FROM Pipeline pl
                 JOIN FETCH pl.jenkinsInfo
+                JOIN FETCH pl.script
                 WHERE pl.id = :pipelineId
             """)
     Optional<Pipeline> findPipelineById(@Param("pipelineId") UUID pipelineId);

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/ConfigService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/ConfigService.java
@@ -4,6 +4,7 @@ import com.example.backend.exception.CustomException;
 import com.example.backend.exception.ErrorCode;
 import com.example.backend.jenkins.job.model.Script;
 import com.example.backend.jenkins.job.model.dto.RequestDto;
+import com.example.backend.util.CronExpressionUtil;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import lombok.RequiredArgsConstructor;
@@ -107,6 +108,14 @@ public class ConfigService {
 
             context.put("githubUrl", githubUrl);
             context.put("script", sc);
+        }
+
+        if (createDto.getSchedule() != null) {
+
+            // 받은 스케줄로 cron식 생성
+            String cronExpression = CronExpressionUtil.toCron(createDto.getSchedule());
+
+            context.put("cronExpression", cronExpression);
         }
 
         return context;

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
@@ -8,6 +8,7 @@ import com.example.backend.jenkins.job.model.dto.ResponseDto;
 import com.example.backend.jenkins.job.repository.ScriptRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -53,6 +54,11 @@ public class ScriptService {
         }
 
         return ResponseDto.entityToLightScriptDto(newScript);
+    }
+
+    @Transactional
+    public void deleteScript(UUID scriptId) {
+        scriptRepository.deleteById(scriptId);
     }
 
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
@@ -27,7 +27,13 @@ public class ScriptService {
         }
         return script;
     }
-    
+
+    /**
+     * Script 만들어서 LightScriptDto로 반환
+     *
+     * @param requestDto SCriptBaseDto 타입
+     * @return
+     */
     public ResponseDto.LightScriptDto generateScript(RequestDto.ScriptBaseDto requestDto) {
         UUID scriptId = requestDto.getScriptId();
         Script newScript = null;
@@ -48,4 +54,5 @@ public class ScriptService {
 
         return ResponseDto.entityToLightScriptDto(newScript);
     }
+
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
@@ -1,0 +1,51 @@
+package com.example.backend.jenkins.job.service;
+
+import com.example.backend.exception.CustomException;
+import com.example.backend.exception.ErrorCode;
+import com.example.backend.jenkins.job.model.Script;
+import com.example.backend.jenkins.job.model.dto.RequestDto;
+import com.example.backend.jenkins.job.model.dto.ResponseDto;
+import com.example.backend.jenkins.job.repository.ScriptRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ScriptService {
+
+    private final ConfigService configService;
+    private final ScriptRepository scriptRepository;
+
+    public Script getScriptById(UUID scriptId) {
+        Optional<Script> optionalScript = scriptRepository.findById(scriptId);
+        Script script = null;
+        if (optionalScript.isPresent()) {
+            script = optionalScript.get();
+        }
+        return script;
+    }
+    
+    public ResponseDto.LightScriptDto generateScript(RequestDto.ScriptBaseDto requestDto) {
+        UUID scriptId = requestDto.getScriptId();
+        Script newScript = null;
+        if (scriptId != null) {
+            if (!scriptRepository.existsById(scriptId)) {
+                throw new CustomException(ErrorCode.JENKINS_SCRIPT_NOT_FOUND);
+            }
+            String script = configService.createScript(configService.buildScriptContext(requestDto));
+            newScript = Script.toEntity(requestDto, script);
+            newScript.setId(scriptId);
+
+            newScript = scriptRepository.save(newScript);
+        } else {
+            String script = configService.createScript(configService.buildScriptContext(requestDto));
+
+            newScript = scriptRepository.save(Script.toEntity(requestDto, script));
+        }
+
+        return ResponseDto.entityToLightScriptDto(newScript);
+    }
+}

--- a/backend/src/main/java/com/example/backend/util/CronExpressionUtil.java
+++ b/backend/src/main/java/com/example/backend/util/CronExpressionUtil.java
@@ -1,0 +1,118 @@
+package com.example.backend.util;
+
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 사용자 친화적인 시간 및 주기 표현을 cron 식으로 변환하는 유틸리티 클래스
+ */
+@Component
+public class CronExpressionUtil {
+    // cron 템플릿: 초 분 시 일 월 요일
+    private static final String CRON_DAILY_TEMPLATE = "0 %d %d * * ?";
+    private static final String CRON_WEEKLY_TEMPLATE = "0 %d %d ? * %s";
+
+    // 한글 오전/오후 패턴
+    private static final Pattern KOREAN_TIME_PATTERN = Pattern.compile(
+            "(오전|오후)\\s*(\\d{1,2})시\\s*(\\d{1,2})분?"
+    );
+
+    // 주기 + (요일) + 시간 패턴: ex) "매주 월,수,금 오후 3시 5분"
+    private static final Pattern SCHEDULE_PATTERN = Pattern.compile(
+            "^(매일|매주)\\s*(?:([월화수목금토일](?:,\\s*[월화수목금토일])*)(?:요일)?)?\\s*(오전\\s*\\d{1,2}시\\s*\\d{1,2}분?|오후\\s*\\d{1,2}시\\s*\\d{1,2}분?|\\d{1,2}:\\d{1,2})$"
+    );
+
+    // 한글 요일 -> Cron 요일 표현
+    private static final Map<String, String> DOW_MAP = new HashMap<>();
+
+    static {
+        DOW_MAP.put("일", "SUN");
+        DOW_MAP.put("월", "MON");
+        DOW_MAP.put("화", "TUE");
+        DOW_MAP.put("수", "WED");
+        DOW_MAP.put("목", "THU");
+        DOW_MAP.put("금", "FRI");
+        DOW_MAP.put("토", "SAT");
+    }
+
+    /**
+     * 예) "매일 09:30", "매주 월,수,금 오전 9시 30분"
+     */
+    public static String toCron(String userSchedule) {
+        Matcher schedM = SCHEDULE_PATTERN.matcher(userSchedule.trim());
+        if (!schedM.matches()) {
+            throw new IllegalArgumentException("지원하지 않는 형식입니다: " + userSchedule);
+        }
+
+        String freq = schedM.group(1);
+        String days = schedM.group(2);
+        String timePart = schedM.group(3);
+
+        // 시간 파싱
+        LocalTime time = parseTime(timePart);
+        int hour = time.getHour();
+        int minute = time.getMinute();
+
+        // cron 생성
+        if ("매일".equals(freq)) {
+            return String.format(CRON_DAILY_TEMPLATE, minute, hour);
+        } else {
+            // 매주
+            String dowCron;
+            if (days == null || days.isEmpty()) {
+                // 요일 지정 없으면 월~일 모두
+                dowCron = String.join(",", DOW_MAP.values());
+            } else {
+                String[] tokens = days.split("\\s*,\\s*");
+                List<String> cronDays = new ArrayList<>();
+                for (String token : tokens) {
+                    String abbr = DOW_MAP.get(token);
+                    if (abbr == null) throw new IllegalArgumentException("알 수 없는 요일: " + token);
+                    cronDays.add(abbr);
+                }
+                dowCron = String.join(",", cronDays);
+            }
+            return String.format(CRON_WEEKLY_TEMPLATE, minute, hour, dowCron);
+        }
+    }
+
+    private static LocalTime parseTime(String input) {
+        String trimmed = input.trim();
+        // 한글 오전/오후
+        Matcher m = KOREAN_TIME_PATTERN.matcher(trimmed);
+        if (m.matches()) {
+            String amPm = m.group(1);
+            int h = Integer.parseInt(m.group(2));
+            int mnt = Integer.parseInt(m.group(3));
+            if ("오후".equals(amPm) && h < 12) h += 12;
+            if ("오전".equals(amPm) && h == 12) h = 0;
+            return LocalTime.of(h, mnt);
+        }
+        throw new IllegalArgumentException("시간을 파싱할 수 없습니다: " + input);
+    }
+
+    // 테스트
+    public static void main(String[] args) {
+        String[] samples = {
+                "매일 9:30",
+                "매주 3:00",
+                "매주 월,수, 목, 금 오후 12시 35분"
+        };
+        for (String s : samples) {
+            try {
+                System.out.printf("%s -> %s%n", s, toCron(s));
+            } catch (Exception e) {
+                System.err.printf("파싱 실패: %s (%s)%n", s, e.getMessage());
+            }
+        }
+    }
+}
+

--- a/backend/src/main/resources/template/config.mustache
+++ b/backend/src/main/resources/template/config.mustache
@@ -23,6 +23,11 @@
                     <spec></spec>
                 </com.cloudbees.jenkins.GitHubPushTrigger>
         {{/trigger}}
+        {{#cronExpression}}
+              <hudson.triggers.TimerTrigger>
+                  <spec>{{cronExpression}}</spec>
+              </hudson.triggers.TimerTrigger>
+        {{/cronExpression}}
     </triggers>
     <disabled>false</disabled>
 </flow-definition>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #109 

## 📝작업 내용

>  Script 분리, Job 상세 조회에 script 포함되게 바꿨습니다.
>  Script 삭제 api 생성
>  사용자 친화적 시간(예: 매주 월, 화 오후 11시 10분)으로 스케줄 설정이 가능하게 했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

**체크리스트**

- [ ] 코드 컨벤션을 준수했는가? (파일명, 네이밍, 포맷 등)
- [ ] 새로운 기능/버그 수정에 대한 단위 테스트 작성 및 통과했는가?
- [ ] 통합 테스트 및 시나리오 테스트를 통과했는가?
- [ ] 문서(Docs) 업데이트가 필요한 경우 반영했는가?
- [ ] 주요 로직에 적절한 주석이 포함되었는가?
- [ ] 보안/성능 고려 사항 검토했는가?
- [ ] 관련 브랜치 전략 및 머지 대상이 적절한가?
