### PR TITLE
[feat] http요청 위치 변경, Job 삭제 로직 변경

### DIFF
--- a/backend/src/main/java/com/example/backend/jenkins/job/repository/StageRepository.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/repository/StageRepository.java
@@ -1,0 +1,17 @@
+package com.example.backend.jenkins.job.repository;
+
+import com.example.backend.jenkins.job.model.Stage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface StageRepository extends JpaRepository<Stage, UUID> {
+    @Modifying
+    @Query("delete from Stage s where s.pipeline.id = :pipelineId")
+    void deleteByPipelineId(@Param("pipelineId") UUID pipelineId);
+}

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/JobEvent.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/JobEvent.java
@@ -2,25 +2,39 @@ package com.example.backend.jenkins.job.service;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 
 import java.util.UUID;
 
 public class JobEvent {
     @Getter
     @AllArgsConstructor
-    public static class JobCreatedEvent {
+    public static class JobCreatedEvent<T> {
         private final UUID pipelineId;
-        private final String config;
         private final String url;
-
+        private final HttpMethod method;
+        private final HttpEntity<?> requestEntity;
+        private final Class<T> responseType;
     }
 
     @Getter
     @AllArgsConstructor
-    public static class JobUpdatedEvent {
+    public static class JobUpdatedEvent<T> {
         private final UUID pipelineId;
-        private final String config;
         private final String url;
+        private final HttpMethod method;
+        private final HttpEntity<?> requestEntity;
+        private final Class<T> responseType;
+    }
 
+    @Getter
+    @AllArgsConstructor
+    public static class JobDeletedEvent<T> {
+        private final UUID pipelineId;
+        private final String url;
+        private final HttpMethod method;
+        private final HttpEntity<?> requestEntity;
+        private final Class<T> responseType;
     }
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/JobEventListener.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/JobEventListener.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class JobCreatedListener {
+public class JobEventListener {
 
     private final HttpClientService httpClientService;
     private final PipelineRepository pipelineRepository;
@@ -40,14 +40,14 @@ public class JobCreatedListener {
         }
     }
 
-    private void handleJobDeleted(JobEvent.JobDeletedEvent<?> evt) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleJobDeleted(JobEvent.JobDeletedEvent<?> evt) {
         try {
             httpClientService.exchange(evt.getUrl(), evt.getMethod(), evt.getRequestEntity(), evt.getResponseType());
         } catch (Exception e) {
-            //TODO delete 실패시 soft-delete 롤백
-            //TODO jenkins 서버에 이미 delete되있으면 그대로
+            //TODO 삭제 요청 실패시 soft-delete 롤백
+            //TODO jenkins 서버에 이미 없는 job일 경우 soft-delete 그대로
         }
     }
-
 }
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/StageService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/StageService.java
@@ -1,0 +1,18 @@
+package com.example.backend.jenkins.job.service;
+
+import com.example.backend.jenkins.job.repository.StageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class StageService {
+
+    private final StageRepository stageRepository;
+
+    public void deleteByPipelineId(UUID pipelineId) {
+        stageRepository.deleteByPipelineId(pipelineId);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #109 

## 📝작업 내용

> JobEventListener에서 http 요청을 생성해 보내는게 아닌 인수로 받아서 처리하도록 변경했습니다. 
> soft-delete로직에서 실제로 jenkins 서버에서도 삭제되도록 했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

**체크리스트**

- [ ] 코드 컨벤션을 준수했는가? (파일명, 네이밍, 포맷 등)
- [ ] 새로운 기능/버그 수정에 대한 단위 테스트 작성 및 통과했는가?
- [ ] 통합 테스트 및 시나리오 테스트를 통과했는가?
- [ ] 문서(Docs) 업데이트가 필요한 경우 반영했는가?
- [ ] 주요 로직에 적절한 주석이 포함되었는가?
- [ ] 보안/성능 고려 사항 검토했는가?
- [ ] 관련 브랜치 전략 및 머지 대상이 적절한가?
