### PR TITLE
[Feat] 파이프라인 버전 관리

### DIFF
--- a/backend/src/main/java/com/example/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/config/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig {
 
                                 //swagger
                                 "/swagger**",
-                                "/v3/api-docs/**"
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/backend/src/main/java/com/example/backend/jenkins/info/controller/JenkinsInfoController.java
+++ b/backend/src/main/java/com/example/backend/jenkins/info/controller/JenkinsInfoController.java
@@ -2,6 +2,7 @@ package com.example.backend.jenkins.info.controller;
 
 import com.example.backend.auth.user.model.Users;
 import com.example.backend.exception.BaseResponse;
+import com.example.backend.jenkins.info.model.dto.InfoRequestDto;
 import com.example.backend.jenkins.info.model.dto.InfoRequestDto.CreateDto;
 import com.example.backend.jenkins.info.model.dto.InfoRequestDto.InfoDto;
 import com.example.backend.jenkins.info.model.dto.InfoRequestDto.UpdateDto;
@@ -10,6 +11,8 @@ import com.example.backend.jenkins.info.model.dto.InfoResponseDto.LightInfoDto;
 import com.example.backend.jenkins.info.service.JenkinsInfoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,6 +45,10 @@ public class JenkinsInfoController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 (필드 누락 또는 형식 오류)"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content = @Content(schema = @Schema(implementation = InfoRequestDto.CreateDto.class))
+    )
     @PostMapping("/create")
     public ResponseEntity<BaseResponse<String>> create(
             @AuthenticationPrincipal(expression = "userEntity") Users user,

--- a/backend/src/main/java/com/example/backend/jenkins/job/controller/JobController.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/controller/JobController.java
@@ -8,6 +8,8 @@ import com.example.backend.jenkins.job.model.dto.ResponseDto;
 import com.example.backend.jenkins.job.service.PipelineService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
@@ -39,6 +41,10 @@ public class JobController {
             @ApiResponse(responseCode = "404", description = "잘못된 JenkinsInfo Id"),
             @ApiResponse(responseCode = "500", description = "Jenkins 서버 문제로 인한 실패")
     })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content = @Content(schema = @Schema(implementation = RequestDto.CreateDto.class))
+    )
     @PreAuthorize("@jenkinsInfoService.isOwner(#user, #requestDto.infoId)")
     @PostMapping("/create")
     public ResponseEntity<BaseResponse<String>> create(
@@ -144,6 +150,18 @@ public class JobController {
     ) {
         return ResponseEntity.ok()
                 .body(BaseResponse.success(pipelineService.getDeletedLightJobs(jenkinsInfoId)));
+    }
+
+    @Operation(
+            summary = "파이프라인 버전 리스트 조회",
+            description = "지정된 파이프라인 ID에 대해 모든 버전 기록을 반환합니다."
+    )
+    @GetMapping("/pipelines/{id}/versions")
+    public ResponseEntity<List<ResponseDto.PipelineVersionDto>> getVersions(
+            @Parameter(description = "버전을 조회할 파이프라인 ID", example = "b1a7c7b2-8123-4cce-80ec-ccf79d5e2f7a")
+            @PathVariable UUID id) {
+        List<ResponseDto.PipelineVersionDto> versions = pipelineService.getPipelineVersions(id);
+        return ResponseEntity.ok(versions);
     }
 
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/Pipeline.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/Pipeline.java
@@ -57,6 +57,9 @@ public class Pipeline {
     @Lob
     private String config;
 
+    @Column(name = "latest_version")
+    private Integer latestVersion;
+
     @OneToOne(fetch = FetchType.LAZY, optional = true)
     @JoinColumn(name = "script_id", nullable = true)
     private Script script;
@@ -68,6 +71,10 @@ public class Pipeline {
     @OneToMany(mappedBy = "pipeline", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("orderIndex ASC")
     private List<Stage> stageList = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "pipeline", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PipelineVersion> versionList = new ArrayList<>();
 
     /*@OneToMany(mappedBy = "pipeline", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PipelineHistory> historyList = new ArrayList<>();*/

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/PipelineVersion.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/PipelineVersion.java
@@ -1,0 +1,59 @@
+package com.example.backend.jenkins.job.model;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.GenericGenerator;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "pipeline_version",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_pipeline_version", columnNames = {"pipeline_id", "version"})
+        })
+@Schema(description = "파이프라인의 버전 정보를 저장하는 엔티티")
+public class PipelineVersion {
+
+    @Id
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @Column(columnDefinition = "CHAR(36)")
+    @Schema(description = "파이프라인 버전 ID", example = "3e6c84f7-7fd2-4f57-8015-3b45528d15df")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pipeline_id", nullable = false)
+    @JsonBackReference
+    @Schema(description = "연결된 파이프라인 객체", hidden = true)
+    private Pipeline pipeline;
+
+    @Column(nullable = false)
+    @Schema(description = "버전 번호", example = "1")
+    private Integer version;
+
+
+    @Column(nullable = false)
+    @Schema(description = "버전 생성 일시", example = "2025-07-15T15:23:00")
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "script_id")
+    @Schema(description = "스크립트 객체 참조", example = "Script 엔티티 참조")
+    private Script script;
+
+    @Lob
+    @Schema(description = "Jenkins XML Config 또는 JSON Config 문자열", example = "<project>...</project>")
+    private String config;
+
+    @Column
+    @Schema(description = "빌드 성공 여부 (true: 성공, false: 실패, null: 빌드 전)", example = "true")
+    private Boolean isSuccessfulBuild;
+
+}

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.backend.jenkins.job.model.dto;
 
 import com.example.backend.jenkins.job.model.Pipeline;
+import com.example.backend.jenkins.job.model.PipelineVersion;
 import com.example.backend.jenkins.job.model.Script;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -59,6 +60,14 @@ public class ResponseDto {
                 .springProfile(script.getSpringProfile())
                 .replicas(script.getReplicas())
                 .script(script.getScript())
+                .build();
+    }
+
+    public static PipelineVersionDto entityToPipelineVersionDto(PipelineVersion version) {
+        return PipelineVersionDto.builder()
+                .version(version.getVersion())
+                .createdAt(version.getCreatedAt())
+                .isSuccessfulBuild(version.getIsSuccessfulBuild())
                 .build();
     }
 
@@ -134,5 +143,16 @@ public class ResponseDto {
         private String replicas;
 
         private String script;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class PipelineVersionDto {
+        private Integer version;
+        private LocalDateTime createdAt;
+        private Boolean isSuccessfulBuild;
+
     }
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/repository/PipelineVersionRepository.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/repository/PipelineVersionRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend.jenkins.job.repository;
+
+import com.example.backend.jenkins.job.model.PipelineVersion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PipelineVersionRepository extends JpaRepository<PipelineVersion, UUID> {
+}

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/PipelineService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/PipelineService.java
@@ -6,6 +6,7 @@ import com.example.backend.exception.ErrorCode;
 import com.example.backend.jenkins.info.model.JenkinsInfo;
 import com.example.backend.jenkins.info.service.JenkinsInfoService;
 import com.example.backend.jenkins.job.model.Pipeline;
+import com.example.backend.jenkins.job.model.PipelineVersion;
 import com.example.backend.jenkins.job.model.Script;
 import com.example.backend.jenkins.job.model.Stage;
 import com.example.backend.jenkins.job.model.dto.RequestDto;
@@ -44,6 +45,7 @@ public class PipelineService {
     private final StageService stageService;
     private final CompensationService compensationService;
 
+    @Transactional
     public void createJob(RequestDto.CreateDto requestDto) {
         // jenkins info 확인
         JenkinsInfo info = jenkinsInfoService.getJenkinsInfo(requestDto.getInfoId());
@@ -77,6 +79,9 @@ public class PipelineService {
             saved.getStageList().add(stage);
         }
         info.getPipelineList().add(saved);
+
+        //버전 저장
+        saveVersion(saved, saved.getScript(), saved.getConfig());
 
         pipelineRepository.flush();
 
@@ -137,6 +142,9 @@ public class PipelineService {
         pipeline.setIsTriggered(requestDto.getTrigger());
         pipeline.setUpdatedAt(LocalDateTime.now());
         pipeline.setConfig(config);
+
+        //버전 저장
+        saveVersion(pipeline, script, config);
 
         // 수정된 job 저장
         Pipeline updated = pipelineRepository.save(pipeline);
@@ -222,4 +230,30 @@ public class PipelineService {
         log.info(info.getUser().getId().toString());
         return userId.equals(confirmUserId);
     }
+
+    public List<ResponseDto.PipelineVersionDto> getPipelineVersions(UUID pipelineId) {
+        Pipeline pipeline = getPipelineById(pipelineId);
+        return pipeline.getVersionList().stream()
+                .map(ResponseDto::entityToPipelineVersionDto)
+                .toList();
+    }
+
+    //새 버전 저장
+    private void saveVersion(Pipeline pipeline, Script script, String config) {
+        Integer newVersion = Optional.ofNullable(pipeline.getLatestVersion()).orElse(0) + 1;
+        pipeline.setLatestVersion(newVersion);
+
+        PipelineVersion version = PipelineVersion.builder()
+                .pipeline(pipeline)
+                .version(newVersion)
+                .createdAt(LocalDateTime.now())
+                .script(script)
+                .config(config)
+                .isSuccessfulBuild(null)
+                .build();
+
+        pipeline.getVersionList().add(version);
+    }
+
+
 }


### PR DESCRIPTION
**🔧 작업 개요**
Swagger 설정 개선 및 파이프라인 버전 관리 기능 추가

**#️⃣ 연관된 이슈**
 #127
추후에 빌드 성공/실패 여부를 저장하여 가장 최근에 빌드 성공한 job으로 롤백하는 기능 추가하면 좋을 것 같습니다.
**📝 작업 내용**
Swagger Security 경로 설정 수정 

@RequestBody에 예제 표시되지 않던 문제 해결 

Jenkins 파이프라인 버전 이력 저장 로직 분리 및 적용 (PipelineVersion 관리)

특정 파이프라인에 대한 버전 리스트 조회 API 추가

📸 스크린샷
(선택) 필요시 Swagger UI 스크린샷 추가

💬 리뷰 요청 사항
- Swagger 설정은 전반적으로 정리했지만, inner class로 DTO를 정의한 경우 @Schema(example = "...")가 Swagger에 제대로 반영되지 않는 문제가 있습니다. 
제가 테스트한 부분은
```
    @io.swagger.v3.oas.annotations.parameters.RequestBody(
            required = true,
            content = @Content(schema = @Schema(implementation = RequestDto.CreateDto.class))
    )
```
이런식으로 dto 직접 지정해주었습니다.

✅ 체크리스트
 코드 컨벤션을 준수했는가?

 기능/버그 관련 단위 테스트 또는 통합 테스트를 수행했는가?

 Swagger 문서가 정상적으로 표시되는가?

 주요 로직에 필요한 주석 또는 설명이 포함되었는가?

 보안/성능에 영향을 줄 수 있는 변경사항은 없는가?

 머지 대상 브랜치 및 전략이 적절한가?