### PR TITLE
[FEAT] 목록, 상세 조회 응답 변경, 삭제 복구 추가

### DIFF
--- a/backend/src/main/java/com/example/backend/jenkins/job/controller/JobController.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/controller/JobController.java
@@ -164,4 +164,17 @@ public class JobController {
         return ResponseEntity.ok(versions);
     }
 
+    @PreAuthorize("@pipelineService.isOwner(#user, #jobId)")
+    @GetMapping("/restoration")
+    public ResponseEntity<BaseResponse<String>> restorationJob(
+            @AuthenticationPrincipal(expression = "userEntity") Users user,
+            @Parameter(description = "조회할 job의 UUID", required = true)
+            @RequestParam UUID jobId
+    ) {
+        pipelineService.restorationJob(jobId);
+
+        return ResponseEntity.ok()
+                .body(BaseResponse.success("restoration job success"));
+    }
+
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/Pipeline.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/Pipeline.java
@@ -50,6 +50,7 @@ public class Pipeline {
     private JenkinsInfo jenkinsInfo;
 
     @Builder.Default
+    @OrderBy("version ASC")
     @OneToMany(mappedBy = "pipeline", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PipelineVersion> versionList = new ArrayList<>();
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/PipelineVersion.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/PipelineVersion.java
@@ -1,6 +1,5 @@
 package com.example.backend.jenkins.job.model;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -29,7 +28,6 @@ public class PipelineVersion {
     @Id
     @GeneratedValue(generator = "UUID")
     @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
-    @Column(columnDefinition = "CHAR(36)")
     @Schema(description = "파이프라인 버전 ID", example = "3e6c84f7-7fd2-4f57-8015-3b45528d15df")
     private UUID id;
 
@@ -70,7 +68,6 @@ public class PipelineVersion {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pipeline_id", nullable = false)
-    @JsonBackReference
     @Schema(description = "연결된 파이프라인 객체", hidden = true)
     private Pipeline pipeline;
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
@@ -16,9 +16,12 @@ import java.util.UUID;
 public class ResponseDto {
 
     public static LightJobDto entityToLightJobDto(Pipeline pipeline) {
+        PipelineVersion pipelineVersion = pipeline.getVersionList().get(pipeline.getLatestVersion() - 1);
+
         return LightJobDto.builder()
                 .pipelineId(pipeline.getId())
                 .name(pipeline.getName())
+                .description(pipelineVersion.getDescription())
                 .build();
     }
 
@@ -102,6 +105,8 @@ public class ResponseDto {
         private UUID pipelineId;
 
         private String name;
+        
+        private String description;
     }
 
     @Data

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
@@ -3,12 +3,14 @@ package com.example.backend.jenkins.job.model.dto;
 import com.example.backend.jenkins.job.model.Pipeline;
 import com.example.backend.jenkins.job.model.PipelineVersion;
 import com.example.backend.jenkins.job.model.Script;
+import com.example.backend.jenkins.job.model.Stage;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public class ResponseDto {
@@ -21,7 +23,7 @@ public class ResponseDto {
     }
 
     public static DetailJobDto entityToDetailJobDto(Pipeline pipeline) {
-        PipelineVersion pipelineVersion = pipeline.getVersionList().get(pipeline.getLatestVersion());
+        PipelineVersion pipelineVersion = pipeline.getVersionList().get(pipeline.getLatestVersion() - 1);
         Script script = pipelineVersion.getScript();
 
         return DetailJobDto.builder()
@@ -33,6 +35,11 @@ public class ResponseDto {
                 .updatedAt(pipeline.getUpdatedAt())
                 .deletedAt(pipeline.getDeletedAt())
                 .lightScriptDto(entityToLightScriptDto(script))
+                .latestVersion(pipeline.getLatestVersion())
+                .stageList(toListOfStageDtos(pipelineVersion.getStageList()))
+                .isSuccessfulBuild(pipelineVersion.getIsSuccessfulBuild())
+                .schedule(pipelineVersion.getSchedule())
+                .pipelineVersionList(toListOfPipelineVersionDtos(pipeline.getVersionList()))
                 .build();
     }
 
@@ -64,11 +71,25 @@ public class ResponseDto {
                 .build();
     }
 
+    public static List<PipelineVersionDto> toListOfPipelineVersionDtos(List<PipelineVersion> pipelines) {
+        return pipelines.stream().map(ResponseDto::entityToPipelineVersionDto).toList();
+    }
+
     public static PipelineVersionDto entityToPipelineVersionDto(PipelineVersion version) {
         return PipelineVersionDto.builder()
                 .version(version.getVersion())
                 .createdAt(version.getCreatedAt())
                 .isSuccessfulBuild(version.getIsSuccessfulBuild())
+                .build();
+    }
+
+    public static List<StageDto> toListOfStageDtos(List<Stage> stageList) {
+        return stageList.stream().map(ResponseDto::entityToStageDto).toList();
+    }
+
+    public static StageDto entityToStageDto(Stage stage) {
+        return StageDto.builder()
+                .stageName(stage.getName())
                 .build();
     }
 
@@ -81,10 +102,6 @@ public class ResponseDto {
         private UUID pipelineId;
 
         private String name;
-
-        private String description;
-
-        private String githubUrl;
     }
 
     @Data
@@ -105,8 +122,18 @@ public class ResponseDto {
         private LocalDateTime createdAt;
         // 수정 시간
         private LocalDateTime updatedAt;
+        // 삭제 시간
         private LocalDateTime deletedAt;
-        private String script;
+        // 최신 버전
+        private Integer latestVersion;
+
+        private Boolean isSuccessfulBuild;
+
+        private String schedule;
+
+        private List<StageDto> stageList;
+
+        private List<PipelineVersionDto> pipelineVersionList;
     }
 
     @Data
@@ -154,6 +181,16 @@ public class ResponseDto {
         private Integer version;
         private LocalDateTime createdAt;
         private Boolean isSuccessfulBuild;
+
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class StageDto {
+
+        private String stageName;
 
     }
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/PipelineService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/PipelineService.java
@@ -235,9 +235,10 @@ public class PipelineService {
     }
 
 
-    /*@Transactional
+    @Transactional
     public void restorationJob(UUID pipelineId) {
         Pipeline pipeline = getPipelineById(pipelineId);
+        PipelineVersion pipelineVersion = getLatestVersion(pipeline);
         JenkinsInfo info = pipeline.getJenkinsInfo();
         LocalDateTime time = pipeline.getDeletedAt();
 
@@ -245,12 +246,12 @@ public class PipelineService {
 
         compensationService.softDeletePipeline(pipeline, null, false);
 
-        String config = pipeline.getConfig();
+        String config = pipelineVersion.getConfig();
 
         callJenkins(info.getUri() + "/createItem?name=" + pipeline.getName(),
                 config, info, HttpMethod.POST,
                 () -> compensationService.softDeletePipeline(pipeline, time, true));
-    }*/
+    }
 
     public List<ResponseDto.PipelineVersionDto> getPipelineVersions(UUID pipelineId) {
         Pipeline pipeline = getPipelineById(pipelineId);

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/PipelineService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/PipelineService.java
@@ -261,7 +261,7 @@ public class PipelineService {
     }
 
     public PipelineVersion getLatestVersion(Pipeline pipeline) {
-        int latestVersion = pipeline.getLatestVersion();
+        int latestVersion = pipeline.getLatestVersion() - 1;
 
         return pipeline.getVersionList().get(latestVersion);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #127  #120 

## 📝작업 내용

> Pipeline 상세 정보를 조회할때 반환하는 정보에 stage, version, schedule, 최신버전을 추가했습니다
> soft-delete된 pipeline을 복구하는 api를 생성했습니다.
> 목록 조회의 반환에 사용되는 LightJobDto에 description 정보를 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

**체크리스트**

- [ ] 코드 컨벤션을 준수했는가? (파일명, 네이밍, 포맷 등)
- [ ] 새로운 기능/버그 수정에 대한 단위 테스트 작성 및 통과했는가?
- [ ] 통합 테스트 및 시나리오 테스트를 통과했는가?
- [ ] 문서(Docs) 업데이트가 필요한 경우 반영했는가?
- [ ] 주요 로직에 적절한 주석이 포함되었는가?
- [ ] 보안/성능 고려 사항 검토했는가?
- [ ] 관련 브랜치 전략 및 머지 대상이 적절한가?
