### PR TITLE
[FEAT] JobNotification 도메인 Swagger 추가

### DIFF
--- a/backend/src/main/java/com/example/backend/jenkins/notification/controller/JobNotificationController.java
+++ b/backend/src/main/java/com/example/backend/jenkins/notification/controller/JobNotificationController.java
@@ -5,6 +5,12 @@ import com.example.backend.exception.BaseResponse;
 import com.example.backend.jenkins.notification.model.dto.RequestDto;
 import com.example.backend.jenkins.notification.model.dto.ResponseDto;
 import com.example.backend.jenkins.notification.service.JobNotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,23 +23,39 @@ import java.util.UUID;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/jenkins/jobNotification")
+@Tag(name = "Job Notification 관리", description = "Jenkins Job 알림 설정 API")
 public class JobNotificationController {
+
     private final JobNotificationService jobNotificationService;
 
+    @Operation(summary = "Job 알림 정보 생성", description = "여러 개의 Jenkins Job 알림 정보를 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PostMapping("/create")
     public ResponseEntity<BaseResponse<String>> create(
-            @RequestBody List<RequestDto.createCredential> dtoList,
-            @AuthenticationPrincipal CustomUserDetails user)
-    {
+            @RequestBody(description = "생성할 알림 정보 목록", required = true)
+            List<RequestDto.createCredential> dtoList,
+            @AuthenticationPrincipal CustomUserDetails user) {
+
         jobNotificationService.createJobNotifications(dtoList, user.getUser().getId());
         return ResponseEntity.ok(
                 BaseResponse.success("create jenkins notification credential success")
         );
     }
 
+    @Operation(summary = "Job 알림 목록 조회", description = "특정 Job ID에 대한 사용자 알림 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 데이터 오류"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PostMapping("/list")
     public ResponseEntity<BaseResponse<List<ResponseDto.JobNotificationListResponseDto>>> getNotificationsForUser(
-            @RequestBody RequestDto.NotificationListRequestDto request
+            @RequestBody(description = "Job ID 포함 요청 객체", required = true)
+            RequestDto.NotificationListRequestDto request
     ) {
         UUID userId = getCurrentUserId();
         List<ResponseDto.JobNotificationListResponseDto> notifications =
@@ -43,9 +65,15 @@ public class JobNotificationController {
                 .body(BaseResponse.success(notifications));
     }
 
+    @Operation(summary = "Job 알림 상세 조회", description = "알림 이름으로 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "알림 자격 정보 없음")
+    })
     @PostMapping("/detail")
     public ResponseEntity<BaseResponse<ResponseDto.JobNotificationDetailResponseDto>> getNotificationDetail(
-            @RequestBody RequestDto.NotificationDetailRequestDto requestDto
+            @RequestBody(description = "알림 이름 요청 객체", required = true)
+            RequestDto.NotificationDetailRequestDto requestDto
     ) {
         ResponseDto.JobNotificationDetailResponseDto dto =
                 jobNotificationService.getNotificationDetail(requestDto.getCredentialName());
@@ -53,19 +81,34 @@ public class JobNotificationController {
                 .body(BaseResponse.success(dto));
     }
 
+    @Operation(summary = "Job 알림 정보 수정", description = "알림 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 데이터 오류"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PostMapping("/update")
     public ResponseEntity<BaseResponse<String>> updateNotification(
-            @RequestBody RequestDto.JobNotificationUpdateRequestDto dto,
+            @RequestBody(description = "수정할 알림 정보", required = true)
+            RequestDto.JobNotificationUpdateRequestDto dto,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
+
         UUID userId = userDetails.getUser().getId();
         jobNotificationService.updateNotification(dto, userId);
         return ResponseEntity.ok()
                 .body(BaseResponse.success("update jenkins notification credential success"));
     }
 
+    @Operation(summary = "Job 알림 정보 삭제", description = "알림 정보를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 오류"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @DeleteMapping("/delete")
     public ResponseEntity<BaseResponse<String>> deleteJobNotification(
-            @RequestBody RequestDto.JobNotificationDeleteRequestDto dto) {
+            @RequestBody(description = "삭제할 알림 정보", required = true)
+            RequestDto.JobNotificationDeleteRequestDto dto) {
 
         UUID userId = getCurrentUserId();
         jobNotificationService.deleteNotification(dto, userId);

--- a/backend/src/main/java/com/example/backend/jenkins/notification/model/dto/RequestDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/notification/model/dto/RequestDto.java
@@ -1,23 +1,37 @@
 package com.example.backend.jenkins.notification.model.dto;
 
-import com.example.backend.jenkins.job.model.Pipeline;
 import com.example.backend.jenkins.notification.model.JobNotification;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
-
 @Data
 public class RequestDto {
 
     @Data
-    public static class createCredential{
+    @Schema(name = "CreateCredentialDto", description = "Job 알림 생성 요청 DTO")
+    public static class createCredential {
+
+        @Schema(description = "Job ID (Pipeline UUID)", example = "d5b77f8e-934b-4b20-afe2-9c30d3329629")
         private UUID jobId;
+
+        @Schema(description = "Script ID (연결된 스크립트 UUID)", example = "c1e2b456-1234-4bcd-a0ef-56789abcdef0")
         private UUID scriptId;
+
+        @Schema(description = "알림 이름", example = "DISCORD_1472d5da_BUILD_SUCCESS_5850a9c6")
         private String name;
+
+        @Schema(description = "이벤트 유형", example = "BUILD_SUCCESS")
         private String eventType;
+
+        @Schema(description = "알림 채널", example = "DISCORD")
         private String channel;
+
+        @Schema(description = "Webhook URL", example = "https://discord.com/api/webhooks/...")
         private String webhookUrl;
+
+        @Schema(description = "알림 여부", example = "true")
         private Boolean shouldNotify;
 
         public JobNotification toEntity(UUID pipelineId, String credentialName) {
@@ -36,25 +50,43 @@ public class RequestDto {
     }
 
     @Data
+    @Schema(name = "SendJobNotificationRequestDto", description = "Job 알림 전송 요청 DTO")
     public static class SendJobNotificationRequestDto {
+
+        @Schema(description = "Job ID (Pipeline UUID)", example = "a1a1a1a1-b2b2-4c4c-d5d5-e6e6e6e6e6e6")
         private UUID jobId;
     }
 
     @Data
+    @Schema(name = "NotificationListRequestDto", description = "Job 알림 목록 조회 요청 DTO")
     public static class NotificationListRequestDto {
+
+        @Schema(description = "Job ID (Pipeline UUID)", example = "b7c7c7b2-8123-4cce-80ec-ccf79d5e2f7a")
         private UUID jobId;
     }
 
     @Data
+    @Schema(name = "NotificationDetailRequestDto", description = "Job 알림 상세 조회 요청 DTO")
     public static class NotificationDetailRequestDto {
+
+        @Schema(description = "Credential 이름", example = "DISCORD_1472d5da_BUILD_SUCCESS_5850a9c6")
         private String credentialName;
     }
 
     @Data
+    @Schema(name = "JobNotificationUpdateRequestDto", description = "Job 알림 수정 요청 DTO")
     public static class JobNotificationUpdateRequestDto {
+
+        @Schema(description = "Credential 이름", example = "DISCORD_1472d5da_BUILD_SUCCESS_5850a9c6")
         private String credentialName;
+
+        @Schema(description = "새 이벤트 유형", example = "BUILD_SUCCESS")
         private String eventType;
+
+        @Schema(description = "새 Webhook URL", example = "https://discord.com/api/webhooks/...")
         private String webhookUrl;
+
+        @Schema(description = "알림 여부", example = "false")
         private Boolean shouldNotify;
 
         public JobNotification toEntity(JobNotification notification) {
@@ -73,7 +105,10 @@ public class RequestDto {
     }
 
     @Data
+    @Schema(name = "JobNotificationDeleteRequestDto", description = "Job 알림 삭제 요청 DTO")
     public static class JobNotificationDeleteRequestDto {
+
+        @Schema(description = "Credential 이름", example = "DISCORD_1472d5da_BUILD_SUCCESS_5850a9c6")
         private String credentialName;
     }
 }

--- a/backend/src/main/java/com/example/backend/jenkins/notification/model/dto/ResponseDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/notification/model/dto/ResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.backend.jenkins.notification.model.dto;
 
 import com.example.backend.jenkins.notification.model.JobNotification;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -11,12 +12,25 @@ public class ResponseDto {
 
     @Builder
     @Data
+    @Schema(name = "JobNotificationListResponseDto", description = "Job 알림 목록 응답 DTO")
     public static class JobNotificationListResponseDto {
+
+        @Schema(description = "Job ID (Pipeline UUID)", example = "b1a7c7b2-8123-4cce-80ec-ccf79d5e2f7a")
         private UUID jobId;
+
+        @Schema(description = "Job 이름", example = "example-job")
         private String jobName;
+
+        @Schema(description = "알림 이벤트 타입", example = "BUILD_FAIL")
         private String eventType;
+
+        @Schema(description = "알림 Credential 이름", example = "DISCORD_1472d5da_BUILD_SUCCESS_5850a9c6")
         private String credentialName;
+
+        @Schema(description = "Webhook URL", example = "https://discord.com/api/webhooks/...")
         private String webhookUrl;
+
+        @Schema(description = "알림 전송 여부", example = "true")
         private Boolean shouldNotify;
 
         public static JobNotificationListResponseDto fromEntity(JobNotification notification) {
@@ -33,12 +47,25 @@ public class ResponseDto {
 
     @Builder
     @Data
+    @Schema(name = "JobNotificationDetailResponseDto", description = "Job 알림 상세 응답 DTO")
     public static class JobNotificationDetailResponseDto {
+
+        @Schema(description = "Job ID (Pipeline UUID)", example = "b1a7c7b2-8123-4cce-80ec-ccf79d5e2f7a")
         private UUID jobId;
+
+        @Schema(description = "Job 이름", example = "example-job")
         private String jobName;
+
+        @Schema(description = "알림 이벤트 타입", example = "BUILD_SUCCESS")
         private String eventType;
+
+        @Schema(description = "알림 Credential 이름", example = "DISCORD_1472d5da_BUILD_SUCCESS_5850a9c6")
         private String credentialName;
+
+        @Schema(description = "Webhook URL", example = "https://discord.com/api/webhooks/...")
         private String webhookUrl;
+
+        @Schema(description = "알림 전송 여부", example = "true")
         private Boolean shouldNotify;
 
         public static JobNotificationDetailResponseDto fromEntity(JobNotification notification) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #151

## 📝작업 내용

> `JobNotification` 관련 API에 Swagger 문서 어노테이션 추가

- `JobNotificationController` 내 API 엔드포인트에 `@Operation`, `@ApiResponse` 등 Swagger 어노테이션 추가
- `RequestDto` 및 `ResponseDto`에 `@Schema` 어노테이션 추가하여 Swagger UI에서 필드 설명, 예시 등 명확히 확인 가능
- 기존 `JobController` Swagger 구성 방식과 일관성 있게 설계

### 스크린샷 (선택)
>

## 💬리뷰 요구사항(선택)

> Swagger에 추가한 필드 설명(`@Schema`)이 실제 API 사용 시 직관적인지 확인 부탁드립니다.
> 
> 예시나 타입 등이 잘못 지정된 부분이 있으면 코멘트 부탁드립니다.

**체크리스트**

- [ ] 코드 컨벤션을 준수했는가? (파일명, 네이밍, 포맷 등)
- [ ] 새로운 기능/버그 수정에 대한 단위 테스트 작성 및 통과했는가?
- [ ] 통합 테스트 및 시나리오 테스트를 통과했는가?
- [ ] 문서(Docs) 업데이트가 필요한 경우 반영했는가?
- [ ] 주요 로직에 적절한 주석이 포함되었는가?
- [ ] 보안/성능 고려 사항 검토했는가?
- [ ] 관련 브랜치 전략 및 머지 대상이 적절한가?
