### PR TITLE
[FEAT] Jwt filter에 Bearer 인증 방식 추가

### DIFF
--- a/backend/src/main/java/com/example/backend/config/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/backend/config/jwt/JwtAuthenticationFilter.java
@@ -30,23 +30,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String path = request.getRequestURI();
         if (
-                //swagger 관련 경로
+            //swagger 관련 경로
                 path.startsWith("/swagger") ||
-                path.startsWith("/v3/api-docs") ||
+                        path.startsWith("/v3/api-docs") ||
 
-                // 인증 관련 허용 경로
-                path.startsWith("/api/email") || // 이메일 인증
-                path.startsWith("/api/auth/reactive") ||
-                path.startsWith("/api/auth/user/signup") ||
-                path.startsWith("/api/auth/user/login") ||
-                path.startsWith("/oauth2/") ||
-                path.startsWith("/login/oauth2/")) {
+                        // 인증 관련 허용 경로
+                        path.startsWith("/api/email") || // 이메일 인증
+                        path.startsWith("/api/auth/reactive") ||
+                        path.startsWith("/api/auth/user/signup") ||
+                        path.startsWith("/api/auth/user/login") ||
+                        path.startsWith("/oauth2/") ||
+                        path.startsWith("/login/oauth2/")) {
             filterChain.doFilter(request, response);
             return;
         }
         String token = null;
 
-        if (request.getCookies() != null) {
+        String bearer = request.getHeader("Authorization");
+        if (bearer != null && bearer.startsWith("Bearer ")) {
+            token = bearer.substring(7);
+        }
+
+        if (token == null && request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {
                 if (accessName.equals(cookie.getName())) {
                     token = cookie.getValue();


### PR DESCRIPTION
기존 Cookie에서 token을 찾는 로직 이전에 Bearer 인증 방식을 추가했습니다.

관련이슈: #158

## #️⃣연관된 이슈

> ex) #이슈번호

#158 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존 Cookie에서 token을 찾는 로직 이전에 Bearer 인증 방식을 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

**체크리스트**

- [x] 코드 컨벤션을 준수했는가? (파일명, 네이밍, 포맷 등)
- [x] 새로운 기능/버그 수정에 대한 단위 테스트 작성 및 통과했는가?
- [x] 통합 테스트 및 시나리오 테스트를 통과했는가?
- [x] 문서(Docs) 업데이트가 필요한 경우 반영했는가?
- [x] 주요 로직에 적절한 주석이 포함되었는가?
- [x] 보안/성능 고려 사항 검토했는가?
- [x] 관련 브랜치 전략 및 머지 대상이 적절한가?
