### PR TITLE
[FEAT] SnapShot 로직 변경, Stage와 PipelineVersion의 연관관계 변경

### DIFF
--- a/backend/src/main/java/com/example/backend/jenkins/job/controller/JobController.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/controller/JobController.java
@@ -259,14 +259,14 @@ public class JobController {
             @ApiResponse(responseCode = "404", description = "해당 버전 ID를 찾을 수 없음"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
-    @PostMapping("/version/{pipelineVersionId}/snapshot")
+    @PostMapping("/version/{jobId}/snapshot")
     public ResponseEntity<BaseResponse<String>> snapshotVersion(
             @Parameter(description = "스냅샷 생성 대상이 될 파이프라인 버전 ID", required = true, example = "c2f4a511-3e55-4db5-b9b3-0123456789ab")
-            @PathVariable UUID pipelineVersionId,
+            @PathVariable UUID jobId,
             @Parameter(description = "생성할 스냅샷 이름", required = true, example = "My Snapshot")
             @RequestParam @NotBlank String snapshotName
     ) {
-        pipelineService.snapshotVersion(pipelineVersionId, snapshotName);
+        pipelineService.snapshotVersion(jobId, snapshotName);
         return ResponseEntity.ok().body(BaseResponse.success("snapshot create success"));
     }
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/PipelineVersion.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/PipelineVersion.java
@@ -98,7 +98,7 @@ public class PipelineVersion {
             description = "해당 버전에서 사용되는 Stage 리스트",
             implementation = Stage.class
     )
-    private List<Stage> stageList = new ArrayList<>();
+    private List<VersionStage> stageList = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pipeline_id")
@@ -108,4 +108,18 @@ public class PipelineVersion {
             hidden = true
     )
     private Pipeline pipeline;
+
+    public static PipelineVersion replicateEntity(PipelineVersion entity, String newName) {
+        return PipelineVersion.builder()
+                .name(newName)
+                .description(entity.getDescription())
+                .isTriggered(entity.getIsTriggered())
+                .schedule(entity.getSchedule())
+                .config(entity.getConfig())
+                .script(entity.getScript())
+                .stageList(new ArrayList<>())
+                .pipeline(entity.getPipeline())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/Stage.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/Stage.java
@@ -6,15 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.GenericGenerator;
 
-import java.util.UUID;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
-@Table(
-        name = "pipeline_stage",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"pipeline_version_id", "order_index"})
-)
 @Data
 @Builder
 @NoArgsConstructor
@@ -26,35 +22,14 @@ import java.util.UUID;
 public class Stage {
 
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
-    @Column(name = "id", updatable = false, nullable = false)
-    @Schema(
-            description = "Stage의 고유 식별자 (UUID)",
-            example = "7e6adf14-8153-41e7-aeb1-2f97782f3b0d"
-    )
-    private UUID id;
-
-    @Column(name = "order_index", nullable = false)
-    @Schema(
-            description = "파이프라인 내에서의 Stage 순서 (0부터 시작)",
-            example = "0"
-    )
-    private Integer orderIndex;
-
-    @Column(name = "name", nullable = false, length = 50)
+    @Column(name = "name", nullable = false, updatable = false, length = 50)
     @Schema(
             description = "Stage의 이름 (보통 대문자, 알파벳·숫자·언더바 등)",
             example = "BUILD"
     )
     private String name;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "pipeline_version_id", nullable = false)
-    @Schema(
-            description = "해당 Stage가 속한 PipelineVersion 엔티티",
-            implementation = PipelineVersion.class,
-            hidden = true
-    )
-    private PipelineVersion pipelineVersion;
+    @Builder.Default
+    @OneToMany(mappedBy = "stage", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<VersionStage> versionList = new ArrayList<>();
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/VersionStage.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/VersionStage.java
@@ -1,0 +1,55 @@
+package com.example.backend.jenkins.job.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+
+import java.util.UUID;
+
+
+@Data
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(
+        name = "version_stage",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"pipeline_version_id", "order_index"})
+)
+public class VersionStage {
+
+    @Id
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "order_index", nullable = false)
+    @Schema(
+            description = "파이프라인 내에서의 Stage 순서 (0부터 시작)",
+            example = "0"
+    )
+    private Integer orderIndex;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stage_id", nullable = false)
+    @Schema(
+            description = "해당 Stage가 속한 PipelineVersion 엔티티",
+            implementation = Stage.class,
+            hidden = true
+    )
+    private Stage stage;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pipeline_version_id", nullable = false)
+    @Schema(
+            description = "해당 Stage가 속한 PipelineVersion 엔티티",
+            implementation = PipelineVersion.class,
+            hidden = true
+    )
+    private PipelineVersion pipelineVersion;
+}

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
@@ -5,7 +5,7 @@ import com.example.backend.exception.ErrorCode;
 import com.example.backend.jenkins.job.model.Pipeline;
 import com.example.backend.jenkins.job.model.PipelineVersion;
 import com.example.backend.jenkins.job.model.Script;
-import com.example.backend.jenkins.job.model.Stage;
+import com.example.backend.jenkins.job.model.VersionStage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -100,13 +100,13 @@ public class ResponseDto {
                 .build();
     }
 
-    public static List<StageDto> toListOfStageDtos(List<Stage> stageList) {
+    public static List<StageDto> toListOfStageDtos(List<VersionStage> stageList) {
         return stageList.stream().map(ResponseDto::entityToStageDto).toList();
     }
 
-    public static StageDto entityToStageDto(Stage stage) {
+    public static StageDto entityToStageDto(VersionStage vs) {
         return StageDto.builder()
-                .stageName(stage.getName())
+                .stageName(vs.getStage().getName())
                 .build();
     }
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/repository/StageRepository.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/repository/StageRepository.java
@@ -2,16 +2,8 @@ package com.example.backend.jenkins.job.repository;
 
 import com.example.backend.jenkins.job.model.Stage;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.UUID;
-
 @Repository
-public interface StageRepository extends JpaRepository<Stage, UUID> {
-    @Modifying
-    @Query("delete from Stage s where s.pipelineVersion.id = :pipelineVersionId")
-    void deleteByPipelineVersionId(@Param("pipelineVersionId") UUID pipelineVersioId);
+public interface StageRepository extends JpaRepository<Stage, String> {
 }

--- a/backend/src/main/java/com/example/backend/jenkins/job/repository/VersionStageRepository.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/repository/VersionStageRepository.java
@@ -1,0 +1,12 @@
+package com.example.backend.jenkins.job.repository;
+
+import com.example.backend.jenkins.job.model.PipelineVersion;
+import com.example.backend.jenkins.job.model.VersionStage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface VersionStageRepository extends JpaRepository<VersionStage, UUID> {
+
+    void deleteVersionStageByPipelineVersion(PipelineVersion pipelineVersion);
+}

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/CompensationService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/CompensationService.java
@@ -2,24 +2,31 @@ package com.example.backend.jenkins.job.service;
 
 import com.example.backend.exception.CustomException;
 import com.example.backend.exception.ErrorCode;
+import com.example.backend.jenkins.info.model.JenkinsInfo;
 import com.example.backend.jenkins.job.model.Pipeline;
 import com.example.backend.jenkins.job.model.PipelineVersion;
-import com.example.backend.jenkins.job.model.Stage;
+import com.example.backend.jenkins.job.model.Script;
 import com.example.backend.jenkins.job.model.dto.SnapshotRollbackDto;
 import com.example.backend.jenkins.job.repository.PipelineRepository;
 import com.example.backend.jenkins.job.repository.PipelineVersionRepository;
+import com.example.backend.service.HttpClientService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class CompensationService {
     private final PipelineRepository pipelineRepository;
+    private final StageService stageService;
+    private final HttpClientService httpClientService;
     private final PipelineVersionRepository pipelineVersionRepository;
 
     @Transactional
@@ -37,6 +44,32 @@ public class CompensationService {
     }
 
     @Transactional
+    public void rollback(PipelineVersion pipelineVersion) {
+
+        Script script = pipelineVersion.getScript();
+        stageService.updateStages(pipelineVersion, script);
+        pipelineVersionRepository.save(pipelineVersion);
+
+    }
+
+    @Transactional
+    public void reCreateJob(PipelineVersion pipelineVersion, JenkinsInfo info, String preName) {
+        // DB 롤백
+        rollback(pipelineVersion);
+
+        // jenkins 서버 롤백
+        String url = info.getUri() + "/createItem?name=" + preName;
+        HttpEntity<String> req = new HttpEntity<>(
+                pipelineVersion.getConfig(),
+                httpClientService.buildHeaders(
+                        info,
+                        new MediaType("application", "xml", StandardCharsets.UTF_8)
+                )
+        );
+        httpClientService.exchange(url, HttpMethod.POST, req, String.class);
+    }
+
+    @Transactional
     public void rollbackLatestVersion(SnapshotRollbackDto dto) {
         Pipeline pipeline = pipelineRepository.findById(dto.getPipelineId())
                 .orElseThrow(() -> new CustomException(ErrorCode.JENKINS_PIPELINE_NOT_FOUND));
@@ -48,12 +81,12 @@ public class CompensationService {
         version.setConfig(dto.getConfig());
         version.setSchedule(dto.getSchedule());
         version.setDescription(dto.getDescription());
-        List<Stage> stages = version.getStageList();
+        /*List<Stage> stages = version.getStageList();
         // 마지막에 추가 됐던 stage 삭제
         if (!stages.isEmpty()) {
             stages.remove(stages.size() - 1);
         }
-        version.setStageList(stages);
+        version.setStageList(stages);*/
         pipelineVersionRepository.save(version);
         pipeline.setLatestVersionId(version.getId());
         pipelineRepository.save(pipeline);

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/PipelineService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/PipelineService.java
@@ -8,26 +8,21 @@ import com.example.backend.jenkins.info.service.JenkinsInfoService;
 import com.example.backend.jenkins.job.model.Pipeline;
 import com.example.backend.jenkins.job.model.PipelineVersion;
 import com.example.backend.jenkins.job.model.Script;
-import com.example.backend.jenkins.job.model.Stage;
+import com.example.backend.jenkins.job.model.VersionStage;
 import com.example.backend.jenkins.job.model.dto.RequestDto;
 import com.example.backend.jenkins.job.model.dto.ResponseDto;
-import com.example.backend.jenkins.job.model.dto.SnapshotRollbackDto;
 import com.example.backend.jenkins.job.repository.PipelineRepository;
 import com.example.backend.jenkins.job.repository.PipelineVersionRepository;
 import com.example.backend.service.HttpClientService;
 import com.example.backend.util.ScriptEditUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -62,7 +57,7 @@ public class PipelineService {
         //파이프라인 & 파이프라인 버전 저장
         Pipeline pipeline = savePipeline(dto, info, script, config, name);
 
-        callJenkins(info.getUri() + "/createItem?name=" + dto.getName(),
+        httpClientService.callJenkins(info.getUri() + "/createItem?name=" + dto.getName(),
                 config, info, HttpMethod.POST,
                 () -> compensationService.deletePipeline(pipeline.getId()));
     }
@@ -75,15 +70,6 @@ public class PipelineService {
         Pipeline pipeline = getPipelineById(dto.getPipelineId());
         PipelineVersion version = getPipelineVersionById(pipeline.getLatestVersionId());
 
-        SnapshotRollbackDto rollbackDto = SnapshotRollbackDto.builder()
-                .versionId(version.getId())
-                .name(version.getName())
-                .isTriggered(version.getIsTriggered())
-                .config(version.getConfig())
-                .description(version.getDescription())
-                .schedule(version.getSchedule())
-                .pipelineId(pipeline.getId())
-                .build();
         JenkinsInfo info = pipeline.getJenkinsInfo();
         String preName = pipeline.getName();
         boolean isRenamed = isRenamed(preName, dto);
@@ -97,42 +83,42 @@ public class PipelineService {
             ensureUniqueName(info.getId(), dto.getName(), pipeline);
 
             // 기존 job 삭제 요청
-            deleteJobOnJenkins(info, preName, () -> compensationService.rollbackLatestVersion(rollbackDto));
+            httpClientService.deleteJobOnJenkins(info, preName,
+                    () -> compensationService.rollback(version));
             // 생성 요청
-            callJenkins(info.getUri() + "/createItem?name=" + dto.getName(),
+            httpClientService.callJenkins(info.getUri() + "/createItem?name=" + dto.getName(),
                     config, info, HttpMethod.POST,
-                    () -> compensationService.rollbackLatestVersion(rollbackDto));
+                    () -> compensationService.reCreateJob(version, info, preName));
         } else {        // 수정할 Job 이름이 같을 때
             // 수정 요청
-            callJenkins(info.getUri() + "/job/" + dto.getName() + "/config.xml",
-                    config, info, HttpMethod.POST, () -> compensationService.rollbackLatestVersion(rollbackDto));
+            httpClientService.callJenkins(info.getUri() + "/job/" + dto.getName() + "/config.xml",
+                    config, info, HttpMethod.POST, () -> compensationService.rollback(version));
         }
     }
 
     @Transactional
-    public void snapshotVersion(UUID pipelineVersionId, String snapshotName) {
-        //스냅샷할 버전
-        PipelineVersion version = pipelineVersionRepository.findById(pipelineVersionId)
-                .orElseThrow(() -> new CustomException(ErrorCode.VERSION_NOT_FOUND));
+    public void snapshotVersion(UUID pipelineId, String snapshotName) {
+        Pipeline pipeline = getPipelineById(pipelineId);
+        PipelineVersion version = getLatestVersion(pipeline);
 
-        PipelineVersion snapshot = PipelineVersion.builder()
-                .name(snapshotName)
-                .description(version.getDescription())
-                .isTriggered(version.getIsTriggered())
-                .schedule(version.getSchedule())
-                .createdAt(LocalDateTime.now())
-                .config(version.getConfig())
-                .script(version.getScript())
-                .stageList(new ArrayList<>(version.getStageList()))
-                .pipeline(version.getPipeline())
-                .build();
+        PipelineVersion snapshot = PipelineVersion.replicateEntity(version, snapshotName);
 
-        version.getPipeline().getVersionList().add(snapshot);
+        List<VersionStage> copiedStages = new ArrayList<>();
+        for (VersionStage orig : version.getStageList()) {
+            VersionStage copied = VersionStage.builder()
+                    .orderIndex(orig.getOrderIndex())
+                    .stage(orig.getStage())
+                    .pipelineVersion(snapshot)
+                    .build();
+            copiedStages.add(copied);
+        }
+        snapshot.setStageList(copiedStages);
+
+        pipeline.getVersionList().add(snapshot);
 
         pipelineVersionRepository.save(snapshot);
-        pipelineVersionRepository.flush();
+        pipelineRepository.save(pipeline);
     }
-
 
     public Pipeline getPipelineById(UUID id) {
         return pipelineRepository.findWithInfoAndScriptById(id)
@@ -145,7 +131,7 @@ public class PipelineService {
         pipeline.setDeletedAt(LocalDateTime.now());
         pipeline.setIsDeleted(true);
         pipelineRepository.save(pipeline);
-        deleteJobOnJenkins(pipeline.getJenkinsInfo(), pipeline.getName(), () -> compensationService.softDeletePipeline(pipeline, null, false));
+        httpClientService.deleteJobOnJenkins(pipeline.getJenkinsInfo(), pipeline.getName(), () -> compensationService.softDeletePipeline(pipeline, null, false));
     }
 
     @Transactional
@@ -215,31 +201,6 @@ public class PipelineService {
         return saved;
     }
 
-    private void createStages(PipelineVersion pipelineVersion, Script script) {
-        List<String> names = extractStageNames(script);
-        for (int i = 0; i < names.size(); i++) {
-            Stage stage = Stage.builder()
-                    .orderIndex(i)
-                    .name(names.get(i))
-                    .pipelineVersion(pipelineVersion)
-                    .build();
-            pipelineVersion.getStageList().add(stage);
-        }
-    }
-
-    public void updateStages(PipelineVersion pipelineVersion, Script script) {
-        stageService.deleteByPipelineVersionId(pipelineVersion.getId());
-        createStages(pipelineVersion, script);
-    }
-
-    private List<String> extractStageNames(Script script) {
-        if (script == null) return Collections.emptyList();
-        return scriptEditUtil.extractStageNames(script.getScript())
-                .stream()
-                .map(s -> s.toUpperCase().replaceAll("\\W+", "_"))
-                .collect(Collectors.toList());
-    }
-
     private void applyPipelineChanges(Pipeline pipeline, RequestDto.UpdateDto dto, Script script, String config) {
         pipeline.setName(dto.getName());
         pipeline.setUpdatedAt(LocalDateTime.now());
@@ -249,38 +210,6 @@ public class PipelineService {
         pipelineRepository.save(pipeline);
         pipelineRepository.flush();
     }
-
-    private void callJenkins(String url, String body, JenkinsInfo info, HttpMethod method, Runnable onError) {
-        HttpEntity<String> req = new HttpEntity<>(
-                body,
-                httpClientService.buildHeaders(
-                        info,
-                        new MediaType("application", "xml", StandardCharsets.UTF_8)
-                )
-        );
-        try {
-            httpClientService.exchange(url, method, req, String.class);
-        } catch (Exception e) {
-            if (onError != null) onError.run();
-            throw e;
-        }
-    }
-
-    private void deleteJobOnJenkins(JenkinsInfo info, String name, Runnable onError) {
-        String url = info.getUri() + "/job/" + name + "/doDelete";
-        HttpEntity<String> req = new HttpEntity<>(
-                httpClientService.buildHeaders(info, MediaType.APPLICATION_FORM_URLENCODED)
-        );
-        try {
-            httpClientService.exchange(url, HttpMethod.POST, req, String.class);
-        } catch (CustomException e) {
-            if (!ErrorCode.INVALID_ENDPOINT.equals(e.getErrorCode())) {
-                if (onError != null) onError.run();
-                throw e;
-            }
-        }
-    }
-
 
     @Transactional
     public void restorationJob(UUID pipelineId) {
@@ -295,7 +224,7 @@ public class PipelineService {
 
         String config = pipelineVersion.getConfig();
 
-        callJenkins(info.getUri() + "/createItem?name=" + pipeline.getName(),
+        httpClientService.callJenkins(info.getUri() + "/createItem?name=" + pipeline.getName(),
                 config, info, HttpMethod.POST,
                 () -> compensationService.softDeletePipeline(pipeline, time, true));
     }
@@ -330,12 +259,12 @@ public class PipelineService {
                 .script(script)
                 .pipeline(pipeline)
                 .build();
+        PipelineVersion savedVersion = pipelineVersionRepository.save(version);
 
-        createStages(version, script);
+        stageService.createStages(savedVersion, script);
 
         pipeline.getVersionList().add(version);
 
-        PipelineVersion savedVersion = pipelineVersionRepository.save(version);
         pipelineVersionRepository.flush();
         return savedVersion.getId();
     }
@@ -348,7 +277,7 @@ public class PipelineService {
         pipelineVersion.setConfig(config);
         pipelineVersion.setScript(script);
 
-        updateStages(pipelineVersion, script);
+        stageService.updateStages(pipelineVersion, script);
 
         pipelineVersionRepository.save(pipelineVersion);
         pipelineVersionRepository.flush();
@@ -391,7 +320,7 @@ public class PipelineService {
         pipeline.setLatestVersionId(snapshotVersionId);
         pipelineRepository.save(pipeline);
 
-        callJenkins(info.getUri() + "/job/" + pipeline.getName() + "/config.xml",
+        httpClientService.callJenkins(info.getUri() + "/job/" + pipeline.getName() + "/config.xml",
                 config, info, HttpMethod.POST, () -> compensationService.rollbackPipelineLatestVersion(pipeline, previousVersionId));
     }
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/StageService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/StageService.java
@@ -1,18 +1,66 @@
 package com.example.backend.jenkins.job.service;
 
+import com.example.backend.jenkins.job.model.PipelineVersion;
+import com.example.backend.jenkins.job.model.Script;
+import com.example.backend.jenkins.job.model.Stage;
+import com.example.backend.jenkins.job.model.VersionStage;
 import com.example.backend.jenkins.job.repository.StageRepository;
+import com.example.backend.jenkins.job.repository.VersionStageRepository;
+import com.example.backend.util.ScriptEditUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class StageService {
 
     private final StageRepository stageRepository;
+    private final VersionStageRepository versionStageRepository;
+    private final ScriptEditUtil scriptEditUtil;
 
-    public void deleteByPipelineVersionId(UUID pipelineVersionId) {
-        stageRepository.deleteByPipelineVersionId(pipelineVersionId);
+    @Transactional
+    public void createStages(PipelineVersion pipelineVersion, Script script) {
+        List<String> names = extractStageNames(script);
+
+        for (int i = 0; i < names.size(); i++) {
+            String stageName = names.get(i);
+
+            Stage stage = stageRepository.findById(stageName)
+                    .orElseGet(() -> {
+                        Stage s = Stage.builder()
+                                .name(stageName)
+                                .build();
+                        return stageRepository.save(s);   // 새로 저장
+                    });
+
+            VersionStage versionStage = VersionStage.builder()
+                    .orderIndex(i)
+                    .stage(stage)
+                    .pipelineVersion(pipelineVersion)
+                    .build();
+            versionStageRepository.save(versionStage);
+
+            pipelineVersion.getStageList().add(versionStage);
+        }
+    }
+
+    @Transactional
+    public void updateStages(PipelineVersion pipelineVersion, Script script) {
+        pipelineVersion.getStageList().clear();
+        versionStageRepository.deleteVersionStageByPipelineVersion(pipelineVersion);
+        createStages(pipelineVersion, script);
+    }
+
+    private List<String> extractStageNames(Script script) {
+        if (script == null) return Collections.emptyList();
+        return scriptEditUtil.extractStageNames(script.getScript())
+                .stream()
+                .map(s -> s.toUpperCase().replaceAll("\\W+", "_"))
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/example/backend/service/HttpClientService.java
+++ b/backend/src/main/java/com/example/backend/service/HttpClientService.java
@@ -12,6 +12,7 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CancellationException;
 
 @Slf4j
@@ -87,6 +88,37 @@ public class HttpClientService {
         headers.setContentType(mediaType);
 
         return headers;
+    }
+
+    public void callJenkins(String url, String body, JenkinsInfo info, HttpMethod method, Runnable onError) {
+        HttpEntity<String> req = new HttpEntity<>(
+                body,
+                buildHeaders(
+                        info,
+                        new MediaType("application", "xml", StandardCharsets.UTF_8)
+                )
+        );
+        try {
+            exchange(url, method, req, String.class);
+        } catch (Exception e) {
+            if (onError != null) onError.run();
+            throw e;
+        }
+    }
+
+    public void deleteJobOnJenkins(JenkinsInfo info, String name, Runnable onError) {
+        String url = info.getUri() + "/job/" + name + "/doDelete";
+        HttpEntity<String> req = new HttpEntity<>(
+                buildHeaders(info, MediaType.APPLICATION_FORM_URLENCODED)
+        );
+        try {
+            exchange(url, HttpMethod.POST, req, String.class);
+        } catch (CustomException e) {
+            if (!ErrorCode.INVALID_ENDPOINT.equals(e.getErrorCode())) {
+                if (onError != null) onError.run();
+                throw e;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호

#143 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


VersionStage 테이블을 추가해서 Stage와 PipelineVersion을 다대다 관계로 연결

- 기존에는 PipelineVersion과 Stage가 일대다로 각 PipelineVersion마다 Stage를 생성했습니다.
- 사용되는 Stage의 이름은 한정되어있기때문에 Stage와 PipelineVersion을 다대다로 연결해서 Stage 이름을 공유하도록 했습니다.

 snapshot로직을 변경

- snapshot 로직에서 pipelineVersionId가 아닌 pipelineId를 받게 수정했습니다.
- StageList를 깊은 복사로 수정했습니다.

update 보상로직 변경

- job update 로직에서 http 요청이 실패할 경우 수행하는 보상로직을 변경했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

**체크리스트**

- [ ] 코드 컨벤션을 준수했는가? (파일명, 네이밍, 포맷 등)
- [ ] 새로운 기능/버그 수정에 대한 단위 테스트 작성 및 통과했는가?
- [ ] 통합 테스트 및 시나리오 테스트를 통과했는가?
- [ ] 문서(Docs) 업데이트가 필요한 경우 반영했는가?
- [ ] 주요 로직에 적절한 주석이 포함되었는가?
- [ ] 보안/성능 고려 사항 검토했는가?
- [ ] 관련 브랜치 전략 및 머지 대상이 적절한가?
