### PR TITLE
[FIX] 프론트 Store /api 분리

### DIFF
--- a/frontend/src/api/JenkinsInfoApi.js
+++ b/frontend/src/api/JenkinsInfoApi.js
@@ -13,7 +13,8 @@ export const jenkinsInfoApi = {
     // Jenkins Info 상세 조회
     getDetail(infoId) {
         return instance.post("/jenkins/info", { infoId })
-            console.log("@@@@ : " + infoId)
+
+
             .then((res) => res.data)
             .catch((error) => {
                 console.error("getDetail error:", error);
@@ -23,9 +24,7 @@ export const jenkinsInfoApi = {
 
     // Jenkins Info 삭제
     delete(infoId) {
-        return instance.delete("/jenkins/info", {
-            data: { infoId },
-        })
+        return instance.delete(`/jenkins/info/${infoId}`)
             .then((res) => res.data)
             .catch((error) => {
                 console.error("delete error:", error);

--- a/frontend/src/api/JenkinsInfoApi.js
+++ b/frontend/src/api/JenkinsInfoApi.js
@@ -1,0 +1,58 @@
+import axios from "axios";
+
+const instance = axios.create({
+    baseURL: "/api",
+    headers: {
+        "Content-Type": "application/json",
+    },
+    withCredentials: true,
+});
+
+
+export const jenkinsInfoApi = {
+    // Jenkins Info 상세 조회
+    getDetail(infoId) {
+        return instance.post("/jenkins/info", { infoId })
+            console.log("@@@@ : " + infoId)
+            .then((res) => res.data)
+            .catch((error) => {
+                console.error("getDetail error:", error);
+                throw error.response?.data?.error || error;
+            });
+    },
+
+    // Jenkins Info 삭제
+    delete(infoId) {
+        return instance.delete("/jenkins/info", {
+            data: { infoId },
+        })
+            .then((res) => res.data)
+            .catch((error) => {
+                console.error("delete error:", error);
+                throw error.response?.data?.error || error;
+            });
+    },
+
+    // Jenkins Info 수정
+    update(payload) {
+
+
+
+        return instance.put("/jenkins/info", payload)
+            .then((res) => res.data)
+            .catch((error) => {
+                console.error("update error:", error);
+                throw error.response?.data?.error || error;
+            });
+    },
+
+    // Jenkins 연결 확인
+    verify(infoId) {
+        return instance.post("/jenkins/info/verification", { infoId })
+            .then((res) => res.data)
+            .catch((error) => {
+                console.error("verify error:", error);
+                throw error.response?.data?.error || error;
+            });
+    },
+};

--- a/frontend/src/pages/users/CicdInfoDetail.vue
+++ b/frontend/src/pages/users/CicdInfoDetail.vue
@@ -2,6 +2,7 @@
 import {onMounted, reactive, ref ,watch} from 'vue';
 import {useJenkinsStore} from "@/stores/useJenkinsStore.js";
 import {useRoute} from "vue-router";
+import {jenkinsInfoApi} from "@/api/JenkinsInfoApi.js";
 
 const route = useRoute();
 
@@ -20,6 +21,8 @@ const data = ref({
 })
 
 
+
+
 onMounted(async () => {
   await jenkinsStore.getJenkinInfoDetail(jenkinsInfoId)
   data.value = { ...jenkinsStore.jenkinsInfoDetail }
@@ -34,7 +37,7 @@ const disableEdit = () => {
   isEdit.value = false;
 };
 async function saveEdit() {
-  await jenkinsStore.updateJenkinsInfoDetail(data.value)
+   await jenkinsStore.updateJenkinsInfoDetail(data.value)
   isEdit.value = false
 }
 

--- a/frontend/src/pages/users/CicdInfoDetail.vue
+++ b/frontend/src/pages/users/CicdInfoDetail.vue
@@ -1,58 +1,55 @@
 <script setup>
-import {onMounted, reactive, ref ,watch} from 'vue';
-import {useJenkinsStore} from "@/stores/useJenkinsStore.js";
-import {useRoute} from "vue-router";
-import {jenkinsInfoApi} from "@/api/JenkinsInfoApi.js";
+import { onMounted, reactive, ref } from 'vue';
+import { useJenkinsStore } from "@/stores/useJenkinsStore.js";
+import { useRoute } from "vue-router";
 
 const route = useRoute();
+const jenkinsStore = useJenkinsStore();
 
-const jenkinsStore = useJenkinsStore()
 const isEdit = ref(false);
-const jenkinsInfoId = route.params.id
+const jenkinsInfoId = route.params.id;
 
-
-const data = ref({
-  apiToken:'',
+const data = reactive({
+  apiToken: '',
   description: '',
   id: '',
   jenkinsId: '',
   name: '',
   uri: ''
-})
+});
 
-
-
+const originalData = reactive({});
 
 onMounted(async () => {
-  await jenkinsStore.getJenkinInfoDetail(jenkinsInfoId)
-  data.value = { ...jenkinsStore.jenkinsInfoDetail }
-})
-
+  await jenkinsStore.getJenkinInfoDetail(jenkinsInfoId);
+  Object.assign(data, jenkinsStore.jenkinsInfoDetail);
+  Object.assign(originalData, jenkinsStore.jenkinsInfoDetail);
+});
 
 const enabledEdit = () => {
   isEdit.value = true;
 };
 
 const disableEdit = () => {
+  Object.assign(data, originalData);
   isEdit.value = false;
 };
-async function saveEdit() {
-   await jenkinsStore.updateJenkinsInfoDetail(data.value)
-  isEdit.value = false
-}
 
+async function saveEdit() {
+  await jenkinsStore.updateJenkinsInfoDetail(data);
+  Object.assign(originalData, data);
+  isEdit.value = false;
+}
 
 async function deleteInfo() {
-  await jenkinsStore.deleteJenkinsInfoDetail(data.value.id)
+  await jenkinsStore.deleteJenkinsInfoDetail(jenkinsInfoId);
 }
+
 async function jenkinsURITest() {
-
-  await jenkinsStore.jenkinsURITest(data.value.id)
+  await jenkinsStore.jenkinsURITest(data.id);
 }
-
 
 </script>
-
 <template>
   <div class="container">
     <div class="header">
@@ -98,7 +95,7 @@ async function jenkinsURITest() {
       </div>
       <div class="row">
         <div class="label">ID</div>
-        <input type="text" v-model="data.id" :readonly="!isEdit" class="input_text" :class="{ editing: isEdit }" />
+        <input type="text" v-model="data.jenkinsId" :readonly="!isEdit" class="input_text" :class="{ editing: isEdit }" />
       </div>
     </div>
   </div>

--- a/frontend/src/pages/users/Mypage.vue
+++ b/frontend/src/pages/users/Mypage.vue
@@ -81,7 +81,7 @@ onMounted(async () => {
         />
       </div>
       <div class="cicd_card_list">
-        <div v-for="info in infoList" class="cicd_card" @click="router.push(`/mypage/cicd/${infod.id}`)">
+        <div v-for="info in infoList" class="cicd_card" @click="router.push(`/mypage/cicd/${info.id}`)">
           <p>{{ info.name }}</p>
           <p class="description">{{ info.description }}</p>
           <p>{{ info.uri }}</p>

--- a/frontend/src/stores/useJenkinsStore.js
+++ b/frontend/src/stores/useJenkinsStore.js
@@ -1,47 +1,34 @@
-import {defineStore} from 'pinia'
-import axios from 'axios'
-
+// src/stores/useJenkinsStore.js
+import { defineStore } from 'pinia';
+import { jenkinsInfoApi } from '@/api/JenkinsInfoApi';
 
 export const useJenkinsStore = defineStore('jenkinsStore', {
-    // 상태
     state: () => ({
         jenkinsInfoDetail: {},
     }),
 
-
     actions: {
         async getJenkinInfoDetail(jenkinsInfoId) {
             try {
-                const response = await axios.post('/api/jenkins/info', {
-                    infoId: jenkinsInfoId
-                });
-                console.log(response.data.data)
+                const response = await jenkinsInfoApi.getDetail(jenkinsInfoId);
 
-
-                this.jenkinsInfoDetail = response.data.data || response.data
+                this.jenkinsInfoDetail = response.data.data;
             } catch (error) {
-                console.error('Error fetching job list:', error);
                 this.jenkinsInfoDetail = [];
             }
         },
+
         async deleteJenkinsInfoDetail(jenkinsInfoId) {
             try {
-                const response = await axios.delete('/api/jenkins/info', {
-                    infoId: jenkinsInfoId
-                });
-                console.log(response.data.data)
-
-
-                this.jenkinsInfoDetail = response.data.data || response.data
+                const data = await jenkinsInfoApi.delete(jenkinsInfoId);
+                this.jenkinsInfoDetail = data;
             } catch (error) {
-                console.error('Error fetching job list:', error);
                 this.jenkinsInfoDetail = [];
             }
         },
+
         async updateJenkinsInfoDetail(form) {
             try {
-
-
                 const payload = {
                     infoId: form.id,
                     name: form.name,
@@ -52,36 +39,20 @@ export const useJenkinsStore = defineStore('jenkinsStore', {
                 }
 
 
-                const response = await axios.put('/api/jenkins/info', payload);
-                console.log(response.data.data)
-
-
-                this.jenkinsInfoDetail = response.data.data || response.data
+                const data = await jenkinsInfoApi.update(payload);
+                this.jenkinsInfoDetail = data;
             } catch (error) {
-                console.error('Error fetching job list:', error);
                 this.jenkinsInfoDetail = [];
             }
         },
+
         async jenkinsURITest(infoId) {
             try {
-
-                const asd = {
-                    infoId: infoId
-
-                }
-
-
-
-                const response = await axios.post('/api/jenkins/info/verification', asd);
-
-
-                return response.data // 또는 return response.data.data
+                return await jenkinsInfoApi.verify(infoId);
             } catch (error) {
-                console.error('Error fetching job list:', error);
                 this.jenkinsInfoDetail = [];
+                return null;
             }
         }
-
-
     }
-})
+});

--- a/frontend/src/stores/useJenkinsStore.js
+++ b/frontend/src/stores/useJenkinsStore.js
@@ -11,7 +11,6 @@ export const useJenkinsStore = defineStore('jenkinsStore', {
         async getJenkinInfoDetail(jenkinsInfoId) {
             try {
                 const response = await jenkinsInfoApi.getDetail(jenkinsInfoId);
-
                 this.jenkinsInfoDetail = response.data.data;
             } catch (error) {
                 this.jenkinsInfoDetail = [];
@@ -20,10 +19,12 @@ export const useJenkinsStore = defineStore('jenkinsStore', {
 
         async deleteJenkinsInfoDetail(jenkinsInfoId) {
             try {
-                const data = await jenkinsInfoApi.delete(jenkinsInfoId);
-                this.jenkinsInfoDetail = data;
+                const res = await jenkinsInfoApi.delete(jenkinsInfoId);
+
+                return res.success === true;
             } catch (error) {
-                this.jenkinsInfoDetail = [];
+                console.error("삭제 실패:", error);
+                return false;
             }
         },
 

--- a/frontend/src/stores/useJobStore.js
+++ b/frontend/src/stores/useJobStore.js
@@ -2,14 +2,14 @@ import { defineStore } from 'pinia'
 import axios from 'axios'
 
 
+
+
+
 export const useJobStore = defineStore('jobstore', {
-    // 상태
+
     state: () => ({
         jobList: [],
-        jenkinsInfo: [
-
-
-        ],
+        jenkinsInfo: [],
     }),
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호
#191 


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- jenkins스토어 생성
- 프론트랑 store 연결
- Info디테일 프론트 표시
- uri jenkins api 연동
- 수정 하다 취소시 원래 데이터로 복구
- 테스트 연동 확인
- 삭제 버튼 연동



### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

**체크리스트**

- [x] 코드 컨벤션을 준수했는가? (파일명, 네이밍, 포맷 등)
- [x] 새로운 기능/버그 수정에 대한 단위 테스트 작성 및 통과했는가?
- [ ] 통합 테스트 및 시나리오 테스트를 통과했는가?
- [ ] 문서(Docs) 업데이트가 필요한 경우 반영했는가?
- [ ] 주요 로직에 적절한 주석이 포함되었는가?
- [ ] 보안/성능 고려 사항 검토했는가?
- [x] 관련 브랜치 전략 및 머지 대상이 적절한가?
