### PR TITLE
[FEAT] Jenkins 알림 메시지 개선 - 실행자 정보 환경변수로 수정 및 링크 추가

### DIFF
--- a/backend/src/main/java/com/example/backend/jenkins/job/controller/ScriptController.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/controller/ScriptController.java
@@ -48,7 +48,7 @@ public class ScriptController {
             @RequestBody RequestDto.ScriptBaseDto requestDto
     ) {
         return ResponseEntity.ok()
-                .body(BaseResponse.success(scriptService.generateScript(requestDto, user.getName())));
+                .body(BaseResponse.success(scriptService.generateScript(requestDto)));
     }
 
     @Operation(

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
@@ -40,7 +40,7 @@ public class ScriptService {
      * @param requestDto SCriptBaseDto 타입
      * @return
      */
-    public ResponseDto.LightScriptDto generateScript(RequestDto.ScriptBaseDto requestDto, String userName) {
+    public ResponseDto.LightScriptDto generateScript(RequestDto.ScriptBaseDto requestDto) {
         UUID scriptId = requestDto.getScriptId();
         Script newScript = null;
         String script = null;
@@ -66,7 +66,7 @@ public class ScriptService {
 
             String injectedScript = scriptEditUtil.injectBooleanParams(script);
             newScript = Script.toEntity(requestDto, injectedScript);
-            //newScript = scriptRepository.save(Script.toEntity(requestDto, injectedScript));
+            newScript = scriptRepository.save(newScript);
 
             if (requestDto.getNotificationList() != null) {
                 JenkinsInfo info = jenkinsInfoService.getJenkinsInfo(requestDto.getInfoId());
@@ -76,7 +76,7 @@ public class ScriptService {
 
         List<JobNotification> enabledNotifications = jobNotificationService.getEnabledNotifications(newScript);
 
-        newScript = jobNotificationService.updateScriptWithJobNotifications(newScript, enabledNotifications, userName);
+        newScript = jobNotificationService.updateScriptWithJobNotifications(newScript, enabledNotifications);
 
         return ResponseDto.entityToLightScriptDto(newScript);
     }

--- a/backend/src/main/java/com/example/backend/jenkins/notification/service/JobNotificationService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/notification/service/JobNotificationService.java
@@ -117,7 +117,7 @@ public class JobNotificationService {
         return result;
     }
 
-    public String createNotificationScript(List<JobNotification> notifications, String userName) {
+    public String createNotificationScript(List<JobNotification> notifications) {
         Mustache mustache = mf.compile("template/notificationScript.mustache");
 
         List<Map<String, Object>> notificationList = notifications.stream().map(n -> {
@@ -133,7 +133,6 @@ public class JobNotificationService {
         }).collect(Collectors.toList());
 
         Map<String, Object> context = new HashMap<>();
-        context.put("userName", userName != null ? userName : "Unknown");
         context.put("notifications", notificationList);
 
         StringWriter writer = new StringWriter();
@@ -222,8 +221,8 @@ public class JobNotificationService {
         httpClientService.exchange(url, HttpMethod.POST, request, String.class);
     }
 
-    public Script updateScriptWithJobNotifications(Script script, List<JobNotification> notifications, String userName) {
-        String newPostBlock = createNotificationScript(notifications, userName);
+    public Script updateScriptWithJobNotifications(Script script, List<JobNotification> notifications) {
+        String newPostBlock = createNotificationScript(notifications);
         String updatedScript = replacePostBlock(script.getScript(), newPostBlock);
         script.setScript(updatedScript);
         return scriptRepository.save(script);

--- a/backend/src/main/resources/template/notificationScript.mustache
+++ b/backend/src/main/resources/template/notificationScript.mustache
@@ -3,95 +3,107 @@ post {
         echo '🎉 빌드가 성공했습니다!'
 
         script {
+            def seconds = (int)(currentBuild.duration / 1000) % 60
+            def minutes = (int)(currentBuild.duration / 1000 / 60)
+            env.TIME_STRING = "${minutes} min ${seconds} sec"
+        }
+
+        wrap([$class: 'BuildUser']) {
+        script {
+            def user = env.BUILD_USER ?: "자동 트리거"
+
+            {{#notifications}}
+                {{#shouldNotify}}
+                    {{#isBuildSuccess}}
+                        {{#isSlack}}
+                            withCredentials([string(credentialsId: '{{credentialId}}', variable: 'WEBHOOK_URL')]) {
+                            sh """
+                            curl -X POST "$WEBHOOK_URL" \
+                            -H "Content-Type: application/json" \
+                            -d '{
+                            "text": "[{{eventType}}] ${env.JOB_NAME} #${env.BUILD_NUMBER} 빌드 성공 🎉\\n실행자: ${user}\\n소요시간: ${TIME_STRING}\\n🔗 URL: ${env.BUILD_URL}"
+                            }'
+                            """
+                            }
+                        {{/isSlack}}
+                        {{^isSlack}}
+                            withCredentials([string(credentialsId: '{{credentialId}}', variable: 'WEBHOOK_URL')]) {
+                            sh """
+                            curl -X POST "$WEBHOOK_URL" \
+                            -H "Content-Type: application/json" \
+                            -d '{
+                            "username": "CI/CD Bot",
+                            "avatar_url": "https://i.imgur.com/CI-CD-Bot.png",
+                            "embeds": [{
+                            "title": "BUILD_SUCCESS 🚀",
+                            "description": "**Job:** ${env.JOB_NAME} #${env.BUILD_NUMBER}\\n**실행자:** ${user}\\n**소요시간:** ${TIME_STRING}\\n**URL:** [바로가기](${env.BUILD_URL})",
+                            "color": 3066993,
+                            "footer": {
+                            "text": "Powered by Jenkins Notification System"
+                            }
+                            }]
+                            }'
+                            """
+                            }
+                        {{/isSlack}}
+                    {{/isBuildSuccess}}
+                {{/shouldNotify}}
+            {{/notifications}}
+        }
+    }
+}
+
+failure {
+    echo '❌ 빌드가 실패했습니다!'
+
+    script {
         def seconds = (int)(currentBuild.duration / 1000) % 60
         def minutes = (int)(currentBuild.duration / 1000 / 60)
         env.TIME_STRING = "${minutes} min ${seconds} sec"
-        }
-
-        {{#notifications}}
-            {{#shouldNotify}}
-                {{#isBuildSuccess}}
-                    {{#isSlack}}
-                        withCredentials([string(credentialsId: '{{credentialId}}', variable: 'WEBHOOK_URL')]) {
-                        sh """
-                        curl -X POST "$WEBHOOK_URL" \
-                        -H "Content-Type: application/json" \
-                        -d '{
-                        "text": "[{{eventType}}] ${env.JOB_NAME} 성공 알림입니다. (실행자: {{userName}}, 소요시간: $TIME_STRING)"
-                        }'
-                        """
-                        }
-                    {{/isSlack}}
-                    {{^isSlack}}
-                        withCredentials([string(credentialsId: '{{credentialId}}', variable: 'WEBHOOK_URL')]) {
-                        sh """
-                        curl -X POST "$WEBHOOK_URL" \
-                        -H "Content-Type: application/json" \
-                        -d '{
-                        "username": "CI/CD Bot",
-                        "avatar_url": "https://i.imgur.com/CI-CD-Bot.png",
-                        "embeds": [{
-                        "title": "BUILD_SUCCESS 🚀",
-                        "description": "**Job:** ${env.JOB_NAME}\\n**실행자:** {{userName}}\\n**소요시간:** $TIME_STRING",
-                        "color": 3066993,
-                        "footer": {
-                        "text": "Powered by Jenkins Notification System"
-                        }
-                        }]
-                        }'
-                        """
-                        }
-                    {{/isSlack}}
-                {{/isBuildSuccess}}
-            {{/shouldNotify}}
-        {{/notifications}}
     }
 
-    failure {
-        echo '❌ 빌드가 실패했습니다!'
+    wrap([$class: 'BuildUser']) {
+            script {
+                def user = env.BUILD_USER ?: "자동 트리거"
 
-        script {
-        def seconds = (int)(currentBuild.duration / 1000) % 60
-        def minutes = (int)(currentBuild.duration / 1000 / 60)
-        env.TIME_STRING = "${minutes} min ${seconds} sec"
+                {{#notifications}}
+                    {{#shouldNotify}}
+                        {{#isBuildFail}}
+                            {{#isSlack}}
+                                withCredentials([string(credentialsId: '{{credentialId}}', variable: 'WEBHOOK_URL')]) {
+                                sh """
+                                curl -X POST "$WEBHOOK_URL" \
+                                -H "Content-Type: application/json" \
+                                -d '{
+                                "text": "[{{eventType}}] ${env.JOB_NAME} #${env.BUILD_NUMBER} 빌드 실패 ❌\\n실행자: ${user}\\n소요시간: ${TIME_STRING}\\n🔗 URL: ${env.BUILD_URL}"
+                                }'
+                                """
+                                }
+                            {{/isSlack}}
+                            {{^isSlack}}
+                                withCredentials([string(credentialsId: '{{credentialId}}', variable: 'WEBHOOK_URL')]) {
+                                sh """
+                                curl -X POST "$WEBHOOK_URL" \
+                                -H "Content-Type: application/json" \
+                                -d '{
+                                "username": "CI/CD Bot",
+                                "avatar_url": "https://i.imgur.com/CI-CD-Bot.png",
+                                "embeds": [{
+                                "title": "BUILD_FAIL ❌",
+                                "description": "**Job:** ${env.JOB_NAME} #${env.BUILD_NUMBER}\\n**실행자:** ${user}\\n**소요시간:** ${TIME_STRING}\\n**URL:** [바로가기](${env.BUILD_URL})",
+                                "color": 15158332,
+                                "footer": {
+                                "text": "Powered by Jenkins Notification System"
+                                }
+                                }]
+                                }'
+                                """
+                                }
+                            {{/isSlack}}
+                        {{/isBuildFail}}
+                    {{/shouldNotify}}
+                {{/notifications}}
+            }
         }
-
-        {{#notifications}}
-            {{#shouldNotify}}
-                {{#isBuildFail}}
-                    {{#isSlack}}
-                        withCredentials([string(credentialsId: '{{credentialId}}', variable: 'WEBHOOK_URL')]) {
-                        sh """
-                        curl -X POST "$WEBHOOK_URL" \
-                        -H "Content-Type: application/json" \
-                        -d '{
-                        "text": "[{{eventType}}] ${env.JOB_NAME} 실패 알림입니다. (실행자: {{userName}}, 소요시간: $TIME_STRING)"
-                        }'
-                        """
-                        }
-                    {{/isSlack}}
-                    {{^isSlack}}
-                        withCredentials([string(credentialsId: '{{credentialId}}', variable: 'WEBHOOK_URL')]) {
-                        sh """
-                        curl -X POST "$WEBHOOK_URL" \
-                        -H "Content-Type: application/json" \
-                        -d '{
-                        "username": "CI/CD Bot",
-                        "avatar_url": "https://i.imgur.com/CI-CD-Bot.png",
-                        "embeds": [{
-                        "title": "BUILD_FAIL ❌",
-                        "description": "**Job:** ${env.JOB_NAME}\\n**실행자:** {{userName}}\\n**소요시간:** $TIME_STRING",
-                        "color": 15158332,
-                        "footer": {
-                        "text": "Powered by Jenkins Notification System"
-                        }
-                        }]
-                        }'
-                        """
-                        }
-                    {{/isSlack}}
-                {{/isBuildFail}}
-            {{/shouldNotify}}
-        {{/notifications}}
     }
 }

--- a/backend/src/test/java/com/example/backend/jenkins/job/controller/ScriptControllerTest.java
+++ b/backend/src/test/java/com/example/backend/jenkins/job/controller/ScriptControllerTest.java
@@ -132,7 +132,8 @@ class ScriptControllerTest {
                 .script("pipeline {\n // generated script... \n}")
                 .build();
 
-        when(scriptService.generateScript(any(RequestDto.ScriptBaseDto.class), any(String.class)))
+        // ✅ 파라미터 수정: userName 제거
+        when(scriptService.generateScript(any(RequestDto.ScriptBaseDto.class)))
                 .thenReturn(responseDto);
 
         mockMvc.perform(post("/api/jenkins/job/script/generate")
@@ -144,6 +145,7 @@ class ScriptControllerTest {
                 .andExpect(jsonPath("$.data.script").exists())
                 .andExpect(jsonPath("$.error").doesNotExist());
 
-        verify(scriptService).generateScript(any(RequestDto.ScriptBaseDto.class), any(String.class));
+        // ✅ verify에서도 userName 제거
+        verify(scriptService).generateScript(any(RequestDto.ScriptBaseDto.class));
     }
 }

--- a/backend/src/test/java/com/example/backend/jenkins/job/service/ScriptServiceTest.java
+++ b/backend/src/test/java/com/example/backend/jenkins/job/service/ScriptServiceTest.java
@@ -82,7 +82,7 @@ class ScriptServiceTest {
         when(scriptRepository.existsById(scriptId)).thenReturn(false);
 
         CustomException ex = assertThrows(CustomException.class, () ->
-                scriptService.generateScript(requestDto, "tester"));
+                scriptService.generateScript(requestDto));
 
         assertEquals(ErrorCode.JENKINS_SCRIPT_NOT_FOUND, ex.getErrorCode());
     }
@@ -98,9 +98,9 @@ class ScriptServiceTest {
         when(scriptEditUtil.injectBooleanParams("rawScript")).thenReturn("editedScript");
         when(jenkinsInfoService.getJenkinsInfo(requestDto.getInfoId())).thenReturn(jenkinsInfo);
         when(jobNotificationService.getEnabledNotifications(any())).thenReturn(Collections.emptyList());
-        when(jobNotificationService.updateScriptWithJobNotifications(any(), any(), any())).thenReturn(script);
+        when(jobNotificationService.updateScriptWithJobNotifications(any(), any())).thenReturn(script);
 
-        ResponseDto.LightScriptDto result = scriptService.generateScript(requestDto, "tester");
+        ResponseDto.LightScriptDto result = scriptService.generateScript(requestDto);
 
         assertNotNull(result);
         verify(jobNotificationService).syncJobNotifications(any(), eq(jenkinsInfo), any());
@@ -118,10 +118,10 @@ class ScriptServiceTest {
         when(scriptEditUtil.injectBooleanParams("rawScript")).thenReturn("editedScript");
         when(jenkinsInfoService.getJenkinsInfo(requestDto.getInfoId())).thenReturn(jenkinsInfo);
         when(jobNotificationService.getEnabledNotifications(any())).thenReturn(Collections.emptyList());
-        when(jobNotificationService.updateScriptWithJobNotifications(any(), any(), any()))
+        when(jobNotificationService.updateScriptWithJobNotifications(any(), any()))
                 .thenReturn(script);
 
-        ResponseDto.LightScriptDto result = scriptService.generateScript(requestDto, "tester");
+        ResponseDto.LightScriptDto result = scriptService.generateScript(requestDto);
 
         assertNotNull(result);
         verify(jobNotificationService).createJobNotifications(any(), eq(jenkinsInfo), any());
@@ -139,9 +139,9 @@ class ScriptServiceTest {
         when(configService.createScript(context)).thenReturn("rawScript");
         when(scriptEditUtil.injectBooleanParams("rawScript")).thenReturn("editedScript");
         when(jobNotificationService.getEnabledNotifications(any())).thenReturn(Collections.emptyList());
-        when(jobNotificationService.updateScriptWithJobNotifications(any(), any(), any()))
+        when(jobNotificationService.updateScriptWithJobNotifications(any(), any()))
                 .thenReturn(script);
 
-        assertDoesNotThrow(() -> scriptService.generateScript(requestDto, "tester"));
+        assertDoesNotThrow(() -> scriptService.generateScript(requestDto));
     }
 }

--- a/backend/src/test/java/com/example/backend/jenkins/job/service/ScriptServiceTest.java
+++ b/backend/src/test/java/com/example/backend/jenkins/job/service/ScriptServiceTest.java
@@ -21,27 +21,16 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class ScriptServiceTest {
 
-    @Mock
-    private ScriptRepository scriptRepository;
+    @Mock private ScriptRepository scriptRepository;
+    @Mock private ConfigService configService;
+    @Mock private JenkinsInfoService jenkinsInfoService;
+    @Mock private JobNotificationService jobNotificationService;
+    @Mock private ScriptEditUtil scriptEditUtil;
 
-    @Mock
-    private ConfigService configService;
-
-    @Mock
-    private JenkinsInfoService jenkinsInfoService;
-
-    @Mock
-    private JobNotificationService jobNotificationService;
-
-    @Mock
-    private ScriptEditUtil scriptEditUtil;
-
-    @InjectMocks
-    private ScriptService scriptService;
+    @InjectMocks private ScriptService scriptService;
 
     private RequestDto.ScriptBaseDto requestDto;
     private JenkinsInfo jenkinsInfo;
@@ -62,7 +51,6 @@ class ScriptServiceTest {
                 .shouldNotify(true)
                 .credentialName("credId")
                 .build();
-
         requestDto.setNotificationList(List.of(notification));
 
         jenkinsInfo = JenkinsInfo.builder()
@@ -98,7 +86,8 @@ class ScriptServiceTest {
         when(scriptEditUtil.injectBooleanParams("rawScript")).thenReturn("editedScript");
         when(jenkinsInfoService.getJenkinsInfo(requestDto.getInfoId())).thenReturn(jenkinsInfo);
         when(jobNotificationService.getEnabledNotifications(any())).thenReturn(Collections.emptyList());
-        when(jobNotificationService.updateScriptWithJobNotifications(any(), any())).thenReturn(script);
+        when(jobNotificationService.updateScriptWithJobNotifications(any(), any()))
+                .thenReturn(script);
 
         ResponseDto.LightScriptDto result = scriptService.generateScript(requestDto);
 
@@ -109,14 +98,14 @@ class ScriptServiceTest {
     @Test
     @DisplayName("generateScript: 새 script 생성 및 알림 등록")
     void generateScript_newScript_success() {
-        requestDto.setScriptId(null); // 새 스크립트 시나리오
-
+        requestDto.setScriptId(null); // 새 script 생성 시나리오
         Map<String, Object> context = Map.of("key", "value");
 
         when(configService.buildScriptContext(requestDto)).thenReturn(context);
         when(configService.createScript(context)).thenReturn("rawScript");
         when(scriptEditUtil.injectBooleanParams("rawScript")).thenReturn("editedScript");
         when(jenkinsInfoService.getJenkinsInfo(requestDto.getInfoId())).thenReturn(jenkinsInfo);
+        when(scriptRepository.save(any())).thenReturn(script);
         when(jobNotificationService.getEnabledNotifications(any())).thenReturn(Collections.emptyList());
         when(jobNotificationService.updateScriptWithJobNotifications(any(), any()))
                 .thenReturn(script);
@@ -124,7 +113,8 @@ class ScriptServiceTest {
         ResponseDto.LightScriptDto result = scriptService.generateScript(requestDto);
 
         assertNotNull(result);
-        verify(jobNotificationService).createJobNotifications(any(), eq(jenkinsInfo), any());
+        verify(scriptRepository).save(any());
+        verify(jobNotificationService).createJobNotifications(any(), eq(jenkinsInfo), eq(scriptId));
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> #155
> #199 

## 📝작업 내용
기존 Jenkins 알림 메시지에서 다음과 같은 문제점이 있었습니다:

- 실행자 이름이 하드코딩되거나 Mustache 템플릿에 수동으로 주입됨
- Jenkins 콘솔 링크가 포함되지 않아 빌드 결과 접근성이 떨어짐

이번 PR에서는 다음과 같은 개선을 적용했습니다:

- `${env.BUILD_USER}` 환경변수를 통해 실행자 정보를 통일된 방식으로 주입
- Jenkins 기본 변수 `${env.BUILD_URL}`을 활용하여 콘솔 링크를 메시지에 포함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

**체크리스트**

- [ ] 코드 컨벤션을 준수했는가? (파일명, 네이밍, 포맷 등)
- [ ] 새로운 기능/버그 수정에 대한 단위 테스트 작성 및 통과했는가?
- [ ] 통합 테스트 및 시나리오 테스트를 통과했는가?
- [ ] 문서(Docs) 업데이트가 필요한 경우 반영했는가?
- [ ] 주요 로직에 적절한 주석이 포함되었는가?
- [ ] 보안/성능 고려 사항 검토했는가?
- [ ] 관련 브랜치 전략 및 머지 대상이 적절한가?
