### PR TITLE
[REFACTOR] Script-JobNotification 책임 분리 및 테스트 코드 보강

### DIFF
--- a/backend/src/main/java/com/example/backend/exception/ErrorCode.java
+++ b/backend/src/main/java/com/example/backend/exception/ErrorCode.java
@@ -102,7 +102,7 @@ public enum ErrorCode {
      */
     JENKINS_FREESTYLE_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "JENKINS_FREESTYLE_HISTORY_NOT_FOUND_404", "해당 freestyle history가 존재하지 않습니다."),
     JENKINS_NOT_SUPPORTED_TOOL(HttpStatus.BAD_REQUEST, "JENKINS_NOT_SUPPORTED_TOOL_400", "지원하지 않는 tool이거나 존재하지 않습니다."),
-    JENKINS_SCRIPT_NOT_FOUND(HttpStatus.BAD_REQUEST, "JENKINS_SCRIPT_NOT_FOUND_400", "Script 정보가 존재하지않습니다."),
+    JENKINS_SCRIPT_NOT_FOUND(HttpStatus.NOT_FOUND, "JENKINS_SCRIPT_NOT_FOUND_404", "Script 정보가 존재하지 않습니다."),
     JENKINS_SCRIPT_NOT_VALID(HttpStatus.BAD_REQUEST, "JENKINS_SCRIPT_NOT_VALID_400", "Script의 문법이 올바르지 않습니다."),
     JENKINS_JOB_EXIST(HttpStatus.BAD_REQUEST, "JENKINS_JOB_EXIST_400", "Jenkins에 이미 동일한 이름의 Job이 존재합니다."),
     CANNOT_DELETE_LATEST_VERSION(HttpStatus.BAD_REQUEST, "CANNOT_DELETE_LATEST_VERSION_400", "최신버전은 삭제 할 수 없습니다."),

--- a/backend/src/main/java/com/example/backend/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/backend/handler/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.io.IOException;
 import java.util.stream.Collectors;
@@ -49,6 +50,23 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
                 .status(errorCode.getHttpStatus().value())
+                .body(BaseResponse.error(errorCode, path));
+    }
+
+    // URL 파라미터 타입 변환 실패 (ex. UUID 잘못된 형식) → 400
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<BaseResponse<Object>> handleTypeMismatch(
+            MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
+
+        ErrorCode errorCode = ErrorCode.VALIDATION_FAILED;
+        String path = request.getRequestURI();
+        String method = request.getMethod();
+
+        log.warn("Type mismatch [{} {}]: parameter={}, requiredType={}, message={}",
+                method, path, ex.getName(), ex.getRequiredType(), ex.getMessage());
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
                 .body(BaseResponse.error(errorCode, path));
     }
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/controller/ScriptController.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/controller/ScriptController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -45,7 +46,7 @@ public class ScriptController {
     @PostMapping("/generate")
     public ResponseEntity<BaseResponse<ResponseDto.LightScriptDto>> generateScript(
             @AuthenticationPrincipal(expression = "userEntity") Users user,
-            @RequestBody RequestDto.ScriptBaseDto requestDto
+            @RequestBody @Valid RequestDto.ScriptBaseDto requestDto
     ) {
         return ResponseEntity.ok()
                 .body(BaseResponse.success(scriptService.generateScript(requestDto)));
@@ -91,7 +92,7 @@ public class ScriptController {
     )
     @PostMapping("/validate")
     public ResponseEntity<BaseResponse<String>> validateScript(
-            @RequestBody RequestDto.ScriptValidateDto requestDto
+            @RequestBody @Valid RequestDto.ScriptValidateDto requestDto
     ) {
         scriptService.validateScript(requestDto);
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/Script.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/Script.java
@@ -1,5 +1,6 @@
 package com.example.backend.jenkins.job.model;
 
+import com.example.backend.jenkins.notification.model.JobNotification;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -119,6 +120,10 @@ public class Script {
             hidden = true // API 응답에서 숨김
     )
     private List<PipelineVersion> pipelineVersionList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "script", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Schema(hidden = true)
+    private List<JobNotification> jobNotificationList = new ArrayList<>();
 
     public static Script toEntity(com.example.backend.jenkins.job.model.dto.RequestDto.ScriptBaseDto requestDto, String script) {
         return Script.builder()

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/dto/RequestDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/dto/RequestDto.java
@@ -2,6 +2,7 @@ package com.example.backend.jenkins.job.model.dto;
 
 import com.example.backend.jenkins.info.model.JenkinsInfo;
 import com.example.backend.jenkins.job.model.Pipeline;
+import com.example.backend.jenkins.job.model.Script;
 import com.example.backend.jenkins.notification.model.JobNotification;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -340,9 +341,9 @@ public class RequestDto {
         @Schema(description = "알림 채널", example = "DISCORD")
         private JobNotification.Channel channel;
 
-        public JobNotification toEntity(String credentialName, UUID scriptId) {
+        public JobNotification toEntity(String credentialName, Script script) {
             return JobNotification.builder()
-                    .scriptId(scriptId)
+                    .script(script)
                     .credentialName(credentialName)
                     .name(this.name)
                     .shouldNotify(this.shouldNotify)

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
@@ -32,7 +32,7 @@ public class ResponseDto {
                 .build();
     }
 
-    public static DetailJobDto entityToDetailJobDto(Pipeline pipeline, List<JobNotification> notifications) {
+    public static DetailJobDto entityToDetailJobDto(Pipeline pipeline) {
 
         UUID latestVersionId = pipeline.getLatestVersionId();
 
@@ -56,11 +56,6 @@ public class ResponseDto {
                 .isBuildSuccess(pipeline.getIsBuildSuccess())
                 .schedule(latestVersion.getSchedule())
                 .pipelineVersionList(toListOfPipelineVersionDtos(pipeline.getVersionList()))
-                .notificationList(
-                        notifications.stream()
-                                .map(ResponseDto.JobNotificationListResponseDto::fromEntity)
-                                .toList()
-                )
                 .build();
     }
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/model/dto/ResponseDto.java
@@ -43,6 +43,12 @@ public class ResponseDto {
 
         Script script = latestVersion.getScript();
 
+        List<JobNotificationListResponseDto> notificationDtos = (script != null && script.getJobNotificationList() != null)
+                ? script.getJobNotificationList().stream()
+                .map(JobNotificationListResponseDto::fromEntity)
+                .toList()
+                : List.of();
+
         return DetailJobDto.builder()
                 .pipelineId(pipeline.getId())
                 .name(pipeline.getName())
@@ -56,6 +62,7 @@ public class ResponseDto {
                 .isBuildSuccess(pipeline.getIsBuildSuccess())
                 .schedule(latestVersion.getSchedule())
                 .pipelineVersionList(toListOfPipelineVersionDtos(pipeline.getVersionList()))
+                .notificationList(notificationDtos)
                 .build();
     }
 
@@ -167,7 +174,8 @@ public class ResponseDto {
 
         @Schema(description = "파이프라인의 전체 버전 기록 리스트")
         private List<PipelineVersionDto> pipelineVersionList;
-
+        
+        @Schema(description = "현재 Job의 알림 설정 목록")
         private List<JobNotificationListResponseDto> notificationList;
     }
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/PipelineService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/PipelineService.java
@@ -131,9 +131,7 @@ public class PipelineService {
 
     public ResponseDto.DetailJobDto getDetailJob(UUID jobId) {
         Pipeline pipeline = getPipelineById(jobId);
-        List<JobNotification> notifications = jobNotificationRepository.findByPipelineId(jobId);
-
-        return ResponseDto.entityToDetailJobDto(pipeline, notifications);
+        return ResponseDto.entityToDetailJobDto(pipeline);
     }
 
     public boolean isOwner(Users user, UUID pipelineId) {

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
@@ -65,6 +65,7 @@ public class ScriptService {
 
     @Transactional
     public void deleteScript(UUID scriptId) {
+        jobNotificationService.deleteAllByScriptId(scriptId);
         scriptRepository.deleteById(scriptId);
     }
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
@@ -28,7 +28,6 @@ public class ScriptService {
     private final ScriptRepository scriptRepository;
     private final JenkinsInfoService jenkinsInfoService;
     private final JobNotificationService jobNotificationService;
-    private final JobNotificationRepository jobNotificationRepository;
 
     public Script getScriptById(UUID scriptId) {
 
@@ -65,7 +64,6 @@ public class ScriptService {
 
     @Transactional
     public void deleteScript(UUID scriptId) {
-        jobNotificationService.deleteAllByScriptId(scriptId);
         scriptRepository.deleteById(scriptId);
     }
 

--- a/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/job/service/ScriptService.java
@@ -9,6 +9,7 @@ import com.example.backend.jenkins.job.model.dto.RequestDto;
 import com.example.backend.jenkins.job.model.dto.ResponseDto;
 import com.example.backend.jenkins.job.repository.ScriptRepository;
 import com.example.backend.jenkins.notification.model.JobNotification;
+import com.example.backend.jenkins.notification.repository.JobNotificationRepository;
 import com.example.backend.jenkins.notification.service.JobNotificationService;
 import com.example.backend.util.ScriptEditUtil;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class ScriptService {
     private final ScriptRepository scriptRepository;
     private final JenkinsInfoService jenkinsInfoService;
     private final JobNotificationService jobNotificationService;
+    private final JobNotificationRepository jobNotificationRepository;
 
     public Script getScriptById(UUID scriptId) {
 
@@ -41,44 +43,24 @@ public class ScriptService {
      * @return
      */
     public ResponseDto.LightScriptDto generateScript(RequestDto.ScriptBaseDto requestDto) {
-        UUID scriptId = requestDto.getScriptId();
-        Script newScript = null;
-        String script = null;
-        if (scriptId != null) {
-            if (!scriptRepository.existsById(scriptId)) {
-                throw new CustomException(ErrorCode.JENKINS_SCRIPT_NOT_FOUND);
-            }
-            script = configService.createScript(configService.buildScriptContext(requestDto));
+        Script script;
 
-            String injectedScript = scriptEditUtil.injectBooleanParams(script);
-
-            newScript = Script.toEntity(requestDto, injectedScript);
-            newScript.setId(scriptId);
-
-            //newScript = scriptRepository.save(newScript);
-
-            if (requestDto.getNotificationList() != null) {
-                JenkinsInfo info = jenkinsInfoService.getJenkinsInfo(requestDto.getInfoId());
-                jobNotificationService.syncJobNotifications(requestDto.getNotificationList(), info, newScript);
-            }
+        if (requestDto.getScriptId() != null) {
+            script = updateExistingScript(requestDto);
         } else {
-            script = configService.createScript(configService.buildScriptContext(requestDto));
-
-            String injectedScript = scriptEditUtil.injectBooleanParams(script);
-            newScript = Script.toEntity(requestDto, injectedScript);
-            newScript = scriptRepository.save(newScript);
-
-            if (requestDto.getNotificationList() != null) {
-                JenkinsInfo info = jenkinsInfoService.getJenkinsInfo(requestDto.getInfoId());
-                jobNotificationService.createJobNotifications(requestDto.getNotificationList(), info, newScript.getId());
-            }
+            script = createNewScript(requestDto);
+            script = scriptRepository.save(script);
         }
 
-        List<JobNotification> enabledNotifications = jobNotificationService.getEnabledNotifications(newScript);
+        handleNotifications(script, requestDto);
 
-        newScript = jobNotificationService.updateScriptWithJobNotifications(newScript, enabledNotifications);
+        List<JobNotification> enabledNotifications = jobNotificationService.getEnabledNotifications(script);
+        String updatedScript = scriptEditUtil.injectNotificationPostBlock(script.getScript(), enabledNotifications);
+        script.setScript(updatedScript);
 
-        return ResponseDto.entityToLightScriptDto(newScript);
+        script = scriptRepository.save(script);
+
+        return ResponseDto.entityToLightScriptDto(script);
     }
 
     @Transactional
@@ -94,6 +76,39 @@ public class ScriptService {
             throw new CustomException(ErrorCode.JENKINS_SCRIPT_NOT_FOUND);
         }
 
+    }
+
+    private Script createNewScript(RequestDto.ScriptBaseDto dto) {
+        String scriptContent = configService.createScript(configService.buildScriptContext(dto));
+        String injectedScript = scriptEditUtil.injectBooleanParams(scriptContent);
+        return Script.toEntity(dto, injectedScript);
+    }
+
+    private Script updateExistingScript(RequestDto.ScriptBaseDto dto) {
+        UUID scriptId = dto.getScriptId();
+        if (!scriptRepository.existsById(scriptId)) {
+            throw new CustomException(ErrorCode.JENKINS_SCRIPT_NOT_FOUND);
+        }
+
+        String scriptContent = configService.createScript(configService.buildScriptContext(dto));
+        String injectedScript = scriptEditUtil.injectBooleanParams(scriptContent);
+
+        Script script = Script.toEntity(dto, injectedScript);
+        script.setId(scriptId);
+        return script;
+    }
+
+    private void handleNotifications(Script script, RequestDto.ScriptBaseDto dto) {
+        List<RequestDto.NotificationDto> notiList = dto.getNotificationList();
+        if (notiList == null || notiList.isEmpty()) return;
+
+        JenkinsInfo info = jenkinsInfoService.getJenkinsInfo(dto.getInfoId());
+
+        if (dto.getScriptId() != null) {
+            jobNotificationService.syncJobNotifications(notiList, info, script);
+        } else {
+            jobNotificationService.createJobNotifications(notiList, info, script.getId());
+        }
     }
 
 }

--- a/backend/src/main/java/com/example/backend/jenkins/notification/model/JobNotification.java
+++ b/backend/src/main/java/com/example/backend/jenkins/notification/model/JobNotification.java
@@ -1,6 +1,7 @@
 package com.example.backend.jenkins.notification.model;
 
 import com.example.backend.jenkins.job.model.Pipeline;
+import com.example.backend.jenkins.job.model.Script;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -29,10 +30,6 @@ public class JobNotification {
     @Schema(description = "알림 이름 (Primary Key)", example = "DISCORD_1472d5da_BUILD_SUCCESS_5850a9c6", requiredMode = Schema.RequiredMode.REQUIRED)
     private String credentialName;
 
-    @Column(name = "script_id", nullable = false)
-    @Schema(description = "스크립트 식별자 (Script UUID)", example = "2de67452-b4aa-46b0-9e3d-523db27c43c4", requiredMode = Schema.RequiredMode.REQUIRED)
-    private UUID scriptId;
-
     @Column(name = "name", nullable = false)
     @Schema(description = "알림 이름", example = "Slack 빌드 성공 알림", requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
@@ -58,6 +55,10 @@ public class JobNotification {
     @Column(name = "event_type", nullable = false)
     @Schema(description = "알림을 보낼 빌드 이벤트 종류", example = "BUILD_SUCCESS", requiredMode = Schema.RequiredMode.REQUIRED)
     private EventType eventType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "script_id", nullable = false, insertable = false, updatable = false)
+    private Script script;
 
     public enum EventType {
         @Schema(description = "빌드 성공 이벤트")

--- a/backend/src/main/java/com/example/backend/jenkins/notification/model/JobNotification.java
+++ b/backend/src/main/java/com/example/backend/jenkins/notification/model/JobNotification.java
@@ -29,15 +29,6 @@ public class JobNotification {
     @Schema(description = "알림 이름 (Primary Key)", example = "DISCORD_1472d5da_BUILD_SUCCESS_5850a9c6", requiredMode = Schema.RequiredMode.REQUIRED)
     private String credentialName;
 
-    @Column(name = "pipeline_id")
-    @Schema(description = "연결된 파이프라인 ID (Pipeline Entity의 UUID)", example = "4fd7a1a1-c209-44a2-b18e-b3e8c73eeb82", requiredMode = Schema.RequiredMode.REQUIRED)
-    private UUID pipelineId;
-
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "pipeline_id", referencedColumnName = "id", insertable = false, updatable = false)
-//    @Schema(description = "연결된 Pipeline 엔티티 객체 (읽기 전용)", hidden = true)
-//    private Pipeline pipeline;
-
     @Column(name = "script_id", nullable = false)
     @Schema(description = "스크립트 식별자 (Script UUID)", example = "2de67452-b4aa-46b0-9e3d-523db27c43c4", requiredMode = Schema.RequiredMode.REQUIRED)
     private UUID scriptId;

--- a/backend/src/main/java/com/example/backend/jenkins/notification/repository/JobNotificationRepository.java
+++ b/backend/src/main/java/com/example/backend/jenkins/notification/repository/JobNotificationRepository.java
@@ -9,8 +9,6 @@ import java.util.UUID;
 
 public interface JobNotificationRepository extends JpaRepository<JobNotification, String> {
 
-    List<JobNotification> findByPipelineId(UUID pipelineId);
-
     List<JobNotification> findByScriptId(UUID scriptId);
 
     List<JobNotification> findByScriptIdAndShouldNotifyTrue(UUID id);

--- a/backend/src/main/java/com/example/backend/jenkins/notification/repository/JobNotificationRepository.java
+++ b/backend/src/main/java/com/example/backend/jenkins/notification/repository/JobNotificationRepository.java
@@ -12,6 +12,4 @@ public interface JobNotificationRepository extends JpaRepository<JobNotification
     List<JobNotification> findByScriptId(UUID scriptId);
 
     List<JobNotification> findByScriptIdAndShouldNotifyTrue(UUID id);
-
-    void deleteAllByScriptId(UUID scriptId);
 }

--- a/backend/src/main/java/com/example/backend/jenkins/notification/repository/JobNotificationRepository.java
+++ b/backend/src/main/java/com/example/backend/jenkins/notification/repository/JobNotificationRepository.java
@@ -12,4 +12,6 @@ public interface JobNotificationRepository extends JpaRepository<JobNotification
     List<JobNotification> findByScriptId(UUID scriptId);
 
     List<JobNotification> findByScriptIdAndShouldNotifyTrue(UUID id);
+
+    void deleteAllByScriptId(UUID scriptId);
 }

--- a/backend/src/main/java/com/example/backend/jenkins/notification/service/JobNotificationService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/notification/service/JobNotificationService.java
@@ -5,7 +5,6 @@ import com.example.backend.exception.ErrorCode;
 import com.example.backend.jenkins.info.model.JenkinsInfo;
 import com.example.backend.jenkins.job.model.Script;
 import com.example.backend.jenkins.job.model.dto.RequestDto;
-import com.example.backend.jenkins.job.model.dto.ResponseDto;
 import com.example.backend.jenkins.job.repository.ScriptRepository;
 import com.example.backend.jenkins.notification.model.JobNotification;
 import com.example.backend.jenkins.notification.repository.JobNotificationRepository;
@@ -37,12 +36,12 @@ public class JobNotificationService {
 
     @Transactional
     public List<JobNotification> createJobNotifications(List<RequestDto.NotificationDto> dtoList, JenkinsInfo info, UUID scriptId) {
+        Script script = scriptRepository.findById(scriptId)
+                .orElseThrow(() -> new CustomException(ErrorCode.JENKINS_SCRIPT_NOT_FOUND));
+
         List<JobNotification> savedNotifications = new ArrayList<>();
 
         for (RequestDto.NotificationDto dto : dtoList) {
-            Script script = scriptRepository.findById(scriptId)
-                    .orElseThrow(() -> new CustomException(ErrorCode.JENKINS_SCRIPT_NOT_FOUND));
-
             String credentialName = generateCredentialName(script.getId(), dto.getChannel(), dto.getEventType());
 
             JobNotification notification = dto.toEntity(credentialName, script);
@@ -219,13 +218,6 @@ public class JobNotificationService {
         HttpEntity<String> request = new HttpEntity<>("Submit=OK", headers);
 
         httpClientService.exchange(url, HttpMethod.POST, request, String.class);
-    }
-
-    public Script updateScriptWithJobNotifications(Script script, List<JobNotification> notifications) {
-        String newPostBlock = createNotificationScript(notifications);
-        String updatedScript = replacePostBlock(script.getScript(), newPostBlock);
-        script.setScript(updatedScript);
-        return scriptRepository.save(script);
     }
 
     public List<JobNotification> getEnabledNotifications(Script script) {

--- a/backend/src/main/java/com/example/backend/jenkins/notification/service/JobNotificationService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/notification/service/JobNotificationService.java
@@ -228,6 +228,8 @@ public class JobNotificationService {
         return scriptRepository.save(script);
     }
 
+
+
     public List<JobNotification> getEnabledNotifications(Script script) {
         return notificationRepository.findByScriptIdAndShouldNotifyTrue(script.getId());
     }

--- a/backend/src/main/java/com/example/backend/jenkins/notification/service/JobNotificationService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/notification/service/JobNotificationService.java
@@ -233,4 +233,9 @@ public class JobNotificationService {
     public List<JobNotification> getEnabledNotifications(Script script) {
         return notificationRepository.findByScriptIdAndShouldNotifyTrue(script.getId());
     }
+
+    @Transactional
+    public void deleteAllByScriptId(UUID scriptId) {
+        notificationRepository.deleteAllByScriptId(scriptId);
+    }
 }

--- a/backend/src/main/java/com/example/backend/jenkins/notification/service/JobNotificationService.java
+++ b/backend/src/main/java/com/example/backend/jenkins/notification/service/JobNotificationService.java
@@ -45,7 +45,7 @@ public class JobNotificationService {
 
             String credentialName = generateCredentialName(script.getId(), dto.getChannel(), dto.getEventType());
 
-            JobNotification notification = dto.toEntity(credentialName, scriptId);
+            JobNotification notification = dto.toEntity(credentialName, script);
             JobNotification saved = notificationRepository.save(notification);
             savedNotifications.add(saved);
 
@@ -80,7 +80,7 @@ public class JobNotificationService {
 
                 createCredential(info, newCredentialName, dto.getWebhookUrl());
 
-                JobNotification created = dto.toEntity(newCredentialName, scriptId);
+                JobNotification created = dto.toEntity(newCredentialName, script);
                 result.add(notificationRepository.save(created));
             } else {
                 boolean changed = false;
@@ -228,14 +228,7 @@ public class JobNotificationService {
         return scriptRepository.save(script);
     }
 
-
-
     public List<JobNotification> getEnabledNotifications(Script script) {
         return notificationRepository.findByScriptIdAndShouldNotifyTrue(script.getId());
-    }
-
-    @Transactional
-    public void deleteAllByScriptId(UUID scriptId) {
-        notificationRepository.deleteAllByScriptId(scriptId);
     }
 }

--- a/backend/src/main/java/com/example/backend/util/ScriptEditUtil.java
+++ b/backend/src/main/java/com/example/backend/util/ScriptEditUtil.java
@@ -1,6 +1,8 @@
 package com.example.backend.util;
 
 import com.example.backend.jenkins.info.model.JenkinsInfo;
+import com.example.backend.jenkins.notification.model.JobNotification;
+import com.example.backend.jenkins.notification.service.JobNotificationService;
 import com.example.backend.service.HttpClientService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
@@ -24,6 +26,7 @@ public class ScriptEditUtil {
             "stage\\s*\\(\\s*['\\\"]([^'\\\"]+)['\\\"]\\s*\\)\\s*\\{"
     );
     private final HttpClientService httpClientService;
+    private final JobNotificationService jobNotificationService;
 
     /**
      * 주어진 Jenkins pipeline script에서 모든 stage 이름을 추출합니다.
@@ -135,6 +138,11 @@ public class ScriptEditUtil {
             result = sb.toString();
         }
         return result;
+    }
+
+    public String injectNotificationPostBlock(String scriptContent, List<JobNotification> notifications) {
+        String newPostBlock = jobNotificationService.createNotificationScript(notifications); // 기존 로직 활용
+        return jobNotificationService.replacePostBlock(scriptContent, newPostBlock); // 기존 로직 활용
     }
 
 

--- a/backend/src/test/java/com/example/backend/jenkins/job/controller/ScriptControllerTest.java
+++ b/backend/src/test/java/com/example/backend/jenkins/job/controller/ScriptControllerTest.java
@@ -2,6 +2,8 @@ package com.example.backend.jenkins.job.controller;
 
 import com.example.backend.auth.user.model.Users;
 import com.example.backend.config.jwt.JwtTokenProvider;
+import com.example.backend.exception.CustomException;
+import com.example.backend.exception.ErrorCode;
 import com.example.backend.jenkins.job.model.dto.RequestDto;
 import com.example.backend.jenkins.job.model.dto.ResponseDto;
 import com.example.backend.jenkins.job.service.ScriptService;
@@ -10,8 +12,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -22,12 +24,10 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.example.backend.jenkins.notification.model.JobNotification.Channel.DISCORD;
-import static com.example.backend.jenkins.notification.model.JobNotification.Channel.SLACK;
 import static com.example.backend.jenkins.notification.model.JobNotification.EventType.BUILD_FAIL;
-import static com.example.backend.jenkins.notification.model.JobNotification.EventType.BUILD_SUCCESS;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -36,116 +36,209 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc(addFilters = false)
 class ScriptControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    @MockitoBean private ScriptService scriptService;
+    @MockitoBean private JwtTokenProvider jwtTokenProvider;
 
-    @MockitoBean
-    private ScriptService scriptService;
-
-    @MockitoBean
-    private JwtTokenProvider jwtTokenProvider;
-
-    public static class UserWrapper {
-        private final Users userEntity;
-
-        public UserWrapper(Users userEntity) {
-            this.userEntity = userEntity;
-        }
-
-        public Users getUserEntity() {
-            return userEntity;
-        }
-    }
+    private UUID userId;
+    private UUID scriptId;
+    private UUID infoId;
 
     @BeforeEach
     void setup() {
+        userId = UUID.randomUUID();
+        scriptId = UUID.randomUUID();
+        infoId = UUID.randomUUID();
+
         Users mockUser = Users.builder()
-                .id(UUID.fromString("2cbf8830-5d58-442a-87fe-fb77919705f1"))
+                .id(userId)
                 .name("테스트유저")
                 .email("test@example.com")
                 .build();
 
-        UserWrapper wrapper = new UserWrapper(mockUser);
-
-        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
-                wrapper, null, List.of()
-        );
-
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(
+                        new Object() {
+                            public Users getUserEntity() {
+                                return mockUser;
+                            }
+                        },
+                        null,
+                        List.of()
+                );
         SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
+    /* -------------------- POST /generate -------------------- */
+
     @Test
-    @DisplayName("POST /api/jenkins/job/script/generate - 성공 시 200 반환 및 서비스 호출")
+    @DisplayName("POST /generate - Script 생성 성공 시 200 반환")
     void generateScript_success() throws Exception {
         RequestDto.ScriptBaseDto requestDto = RequestDto.ScriptBaseDto.builder()
-                .scriptId(UUID.fromString("2cbf8830-5d58-442a-87fe-fb77919705f1"))
-                .infoId(UUID.fromString("fae4b725-01c5-437c-8988-48b3e6c5a34a"))
-                .githubUrl("https://github.com/xxx")
+                .scriptId(scriptId)
+                .infoId(infoId)
+                .githubUrl("https://github.com/example")
                 .branch("main")
                 .isBuildSelected(true)
                 .isTestSelected(true)
-                .isK8sDeploy(true)
+                .isK8sDeploy(false)
                 .tag("v1.0.0")
-                .sshKeyPath("/home/ubuntu/.ssh/id_rsa")
+                .sshKeyPath("/key")
                 .sshPort("22")
-                .deployTarget("ubuntu@192.168.0.10")
-                .k8sPath("./k8s/deployment.yaml")
-                .deploymentName("my-app-deployment")
-                .namespace("default")
-                .appName("my-app")
-                .containerName("my-app-container")
-                .imageRepo("ghcr.io/taehoon0518/my-app")
-                .port("8080")
-                .replicas("2")
-                .notificationList(List.of(
-                        RequestDto.NotificationDto.builder()
-                                .name("디스코드 빌드 실패 알림")
-                                .webhookUrl("https://discord.com/api/webhooks/xxx")
-                                .shouldNotify(true)
-                                .eventType(BUILD_FAIL)
-                                .channel(DISCORD)
-                                .build(),
-
-                        RequestDto.NotificationDto.builder()
-                                .name("슬랙 빌드 실패 알림")
-                                .webhookUrl("https://hooks.slack.com/services/yyyy")
-                                .shouldNotify(false)
-                                .eventType(BUILD_FAIL)
-                                .channel(SLACK)
-                                .build(),
-
-                        RequestDto.NotificationDto.builder()
-                                .name("슬랙 빌드 성공 알림")
-                                .webhookUrl("https://hooks.slack.com/services/yyyy")
-                                .shouldNotify(false)
-                                .eventType(BUILD_SUCCESS)
-                                .channel(SLACK)
-                                .build()
-                ))
+                .deployTarget("ubuntu@1.2.3.4")
+                .notificationList(List.of(RequestDto.NotificationDto.builder()
+                        .channel(DISCORD)
+                        .eventType(BUILD_FAIL)
+                        .webhookUrl("https://discord.com/xxx")
+                        .shouldNotify(true)
+                        .name("빌드 실패 시 디스코드 알람").build()))
                 .build();
 
         ResponseDto.LightScriptDto responseDto = ResponseDto.LightScriptDto.builder()
-                .scriptId(requestDto.getScriptId())
-                .script("pipeline {\n // generated script... \n}")
+                .scriptId(scriptId)
+                .githubUrl("https://github.com/example")
+                .branch("main")
+                .isBuildSelected(true)
+                .isTestSelected(true)
+                .isK8sDeploy(false)
+                .tag("v1.0.0")
+                .sshKeyPath("/key")
+                .sshPort("22")
+                .deployTarget("ubuntu@1.2.3.4")
+                .script("pipeline { ... }")
                 .build();
 
-        // ✅ 파라미터 수정: userName 제거
-        when(scriptService.generateScript(any(RequestDto.ScriptBaseDto.class)))
-                .thenReturn(responseDto);
+        when(scriptService.generateScript(any())).thenReturn(responseDto);
 
         mockMvc.perform(post("/api/jenkins/job/script/generate")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.scriptId").value(requestDto.getScriptId().toString()))
-                .andExpect(jsonPath("$.data.script").exists())
+                .andExpect(jsonPath("$.data.scriptId").value(scriptId.toString()))
                 .andExpect(jsonPath("$.error").doesNotExist());
 
-        // ✅ verify에서도 userName 제거
-        verify(scriptService).generateScript(any(RequestDto.ScriptBaseDto.class));
+        verify(scriptService, times(1)).generateScript(any());
+    }
+
+    @Test
+    @DisplayName("POST /generate - 필수 필드 누락 시 400 반환")
+    void generateScript_missingFields_returnsBadRequest() throws Exception {
+        RequestDto.ScriptBaseDto dto = new RequestDto.ScriptBaseDto();
+
+        mockMvc.perform(post("/api/jenkins/job/script/generate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_FAILED_400"));
+    }
+
+    @Test
+    @DisplayName("POST /generate - 존재하지 않는 ScriptId 수정 시 404 반환")
+    void generateScript_notFoundScriptId_returnsNotFound() throws Exception {
+        RequestDto.ScriptBaseDto dto = RequestDto.ScriptBaseDto.builder()
+                .scriptId(UUID.randomUUID())
+                .infoId(infoId)
+                .githubUrl("https://github.com/example")
+                .branch("main")
+                .isBuildSelected(true)
+                .isTestSelected(true)
+                .build();
+
+        doThrow(new CustomException(ErrorCode.JENKINS_SCRIPT_NOT_FOUND))
+                .when(scriptService).generateScript(any());
+
+        mockMvc.perform(post("/api/jenkins/job/script/generate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("JENKINS_SCRIPT_NOT_FOUND_404"));
+    }
+
+    /* -------------------- POST /validate -------------------- */
+
+    @Test
+    @DisplayName("POST /validate - Script 유효성 검증 성공 시 200 반환")
+    void validateScript_success() throws Exception {
+        RequestDto.ScriptValidateDto dto = new RequestDto.ScriptValidateDto();
+        dto.setInfoId(infoId);
+        dto.setScript("pipeline { ... }");
+
+        mockMvc.perform(post("/api/jenkins/job/script/validate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value("Script validation success"));
+
+        verify(scriptService, times(1)).validateScript(any());
+    }
+
+    @Test
+    @DisplayName("POST /validate - script 필드 누락 시 400 반환")
+    void validateScript_missingScript_returnsBadRequest() throws Exception {
+        RequestDto.ScriptValidateDto dto = new RequestDto.ScriptValidateDto();
+        dto.setInfoId(infoId);
+
+        mockMvc.perform(post("/api/jenkins/job/script/validate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_FAILED_400"));
+    }
+
+    @Test
+    @DisplayName("POST /validate - 존재하지 않는 JenkinsInfo 참조 시 404 반환")
+    void validateScript_jenkinsInfoNotFound_returnsNotFound() throws Exception {
+        RequestDto.ScriptValidateDto dto = new RequestDto.ScriptValidateDto();
+        dto.setInfoId(infoId);
+        dto.setScript("pipeline {}");
+
+        doThrow(new CustomException(ErrorCode.JENKINS_INFO_NOT_FOUND))
+                .when(scriptService).validateScript(any());
+
+        mockMvc.perform(post("/api/jenkins/job/script/validate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("JENKINS_INFO_NOT_FOUND_404"));
+    }
+
+    /* -------------------- DELETE / -------------------- */
+
+    @Test
+    @DisplayName("DELETE / - Script 삭제 성공 시 200 반환")
+    void deleteScript_success() throws Exception {
+        mockMvc.perform(delete("/api/jenkins/job/script")
+                        .param("scriptId", scriptId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("Script deleted success"))
+                .andExpect(jsonPath("$.error").doesNotExist());
+
+        verify(scriptService, times(1)).deleteScript(scriptId);
+    }
+
+    @Test
+    @DisplayName("DELETE / - 잘못된 UUID 형식 파라미터 시 400 반환")
+    void deleteScript_invalidUUID_returnsBadRequest() throws Exception {
+        mockMvc.perform(delete("/api/jenkins/job/script")
+                        .param("scriptId", "invalid-uuid"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_FAILED_400"));
+    }
+
+    @Test
+    @DisplayName("DELETE / - 존재하지 않는 ScriptId 삭제 시 404 반환")
+    void deleteScript_notFound_returnsNotFound() throws Exception {
+        doThrow(new CustomException(ErrorCode.JENKINS_SCRIPT_NOT_FOUND))
+                .when(scriptService).deleteScript(scriptId);
+
+        mockMvc.perform(delete("/api/jenkins/job/script")
+                        .param("scriptId", scriptId.toString()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("JENKINS_SCRIPT_NOT_FOUND_404"));
     }
 }

--- a/backend/src/test/java/com/example/backend/jenkins/job/service/JobNotificationServiceTest.java
+++ b/backend/src/test/java/com/example/backend/jenkins/job/service/JobNotificationServiceTest.java
@@ -1,0 +1,222 @@
+package com.example.backend.jenkins.job.service;
+
+import com.example.backend.exception.CustomException;
+import com.example.backend.jenkins.info.model.JenkinsInfo;
+import com.example.backend.jenkins.job.model.Script;
+import com.example.backend.jenkins.job.model.dto.RequestDto;
+import com.example.backend.jenkins.notification.model.JobNotification;
+import com.example.backend.jenkins.notification.repository.JobNotificationRepository;
+import com.example.backend.jenkins.notification.service.JobNotificationService;
+import com.example.backend.service.HttpClientService;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.*;
+
+import java.io.StringWriter;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JobNotificationServiceTest {
+
+    @Mock private JobNotificationRepository notificationRepository;
+    @Mock private com.example.backend.jenkins.job.repository.ScriptRepository scriptRepository;
+    @Mock private HttpClientService httpClientService;
+    @Mock private MustacheFactory mustacheFactory;
+    @Mock private Mustache mustache;
+
+    @InjectMocks private JobNotificationService jobNotificationService;
+
+    private JenkinsInfo info;
+    private Script script;
+    private UUID scriptId;
+    private RequestDto.NotificationDto dto;
+
+    @BeforeEach
+    void setup() {
+        scriptId = UUID.randomUUID();
+        info = JenkinsInfo.builder().id(UUID.randomUUID()).uri("http://jenkins").build();
+        script = Script.builder().id(scriptId).script("pipeline {}").build();
+
+        dto = RequestDto.NotificationDto.builder()
+                .channel(JobNotification.Channel.SLACK)
+                .eventType(JobNotification.EventType.BUILD_FAIL)
+                .webhookUrl("http://webhook")
+                .shouldNotify(true)
+                .credentialName("cred123")
+                .name("빌드 실패 알림")
+                .build();
+    }
+
+    /* -------------------- createJobNotifications -------------------- */
+
+    @Test
+    @DisplayName("createJobNotifications: scriptId가 DB에 없으면 예외 발생")
+    void createJobNotifications_scriptNotFound() {
+        when(scriptRepository.findById(scriptId)).thenReturn(Optional.empty());
+
+        assertThrows(CustomException.class, () ->
+                jobNotificationService.createJobNotifications(List.of(dto), info, scriptId));
+    }
+
+    @Test
+    @DisplayName("createJobNotifications: 정상 저장 및 Credential 생성 호출")
+    void createJobNotifications_success() {
+        when(scriptRepository.findById(scriptId)).thenReturn(Optional.of(script));
+        when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(httpClientService.exchange(any(), eq(HttpMethod.POST), any(), eq(String.class))).thenReturn(null);
+
+        List<JobNotification> result = jobNotificationService.createJobNotifications(List.of(dto), info, scriptId);
+
+        assertEquals(1, result.size());
+        verify(notificationRepository, times(1)).save(any());
+        verify(httpClientService, times(1)).exchange(any(), eq(HttpMethod.POST), any(), eq(String.class));
+    }
+
+    /* -------------------- syncJobNotifications -------------------- */
+
+    @Test
+    @DisplayName("syncJobNotifications: 신규 알림 생성 시 Credential 생성 및 저장")
+    void syncJobNotifications_createNew() {
+        when(notificationRepository.findByScriptId(scriptId)).thenReturn(Collections.emptyList());
+        when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(httpClientService.exchange(any(), eq(HttpMethod.POST), any(), eq(String.class))).thenReturn(null);
+
+        List<JobNotification> result = jobNotificationService.syncJobNotifications(List.of(dto), info, script);
+
+        assertEquals(1, result.size());
+        verify(notificationRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("syncJobNotifications: 기존 알림이 변경되면 updateCredential 호출 및 저장")
+    void syncJobNotifications_updateExisting() {
+        JobNotification existing = JobNotification.builder()
+                .credentialName("cred123").webhookUrl("old").shouldNotify(false).name("old").script(script).build();
+
+        when(notificationRepository.findByScriptId(scriptId)).thenReturn(List.of(existing));
+        when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(httpClientService.exchange(any(), eq(HttpMethod.POST), any(), eq(String.class))).thenReturn(null);
+
+        List<JobNotification> result = jobNotificationService.syncJobNotifications(List.of(dto), info, script);
+
+        assertEquals(1, result.size());
+        verify(notificationRepository, times(1)).save(existing);
+    }
+
+    @Test
+    @DisplayName("syncJobNotifications: 기존 알림이 incomingList에 없으면 Credential 삭제 및 DB 삭제")
+    void syncJobNotifications_deleteObsolete() {
+        JobNotification existing = JobNotification.builder()
+                .credentialName("oldCred").webhookUrl("url").shouldNotify(true).name("old").script(script).build();
+
+        when(notificationRepository.findByScriptId(scriptId)).thenReturn(List.of(existing));
+        when(httpClientService.exchange(any(), eq(HttpMethod.POST), any(), eq(String.class))).thenReturn(null);
+
+        jobNotificationService.syncJobNotifications(Collections.emptyList(), info, script);
+
+        verify(notificationRepository, times(1)).delete(existing);
+        verify(httpClientService, times(1)).exchange(contains("/doDelete"), eq(HttpMethod.POST), any(), eq(String.class));
+    }
+
+    /* -------------------- createNotificationScript -------------------- */
+
+    @Test
+    @DisplayName("createNotificationScript: 알림 리스트를 Mustache 템플릿으로 변환")
+    void createNotificationScript_success() {
+        when(mustacheFactory.compile("template/notificationScript.mustache")).thenReturn(mustache);
+        doAnswer(inv -> {
+            StringWriter w = inv.getArgument(0, StringWriter.class);
+            w.write("generatedScript");
+            return w;
+        }).when(mustache).execute(any(StringWriter.class), ArgumentMatchers.<Map<String, Object>>any());
+
+        JobNotification notification = JobNotification.builder()
+                .channel(JobNotification.Channel.SLACK)
+                .eventType(JobNotification.EventType.BUILD_FAIL)
+                .webhookUrl("url")
+                .shouldNotify(true)
+                .credentialName("cred")
+                .build();
+
+        String result = jobNotificationService.createNotificationScript(List.of(notification));
+        assertEquals("generatedScript", result);
+    }
+
+    /* -------------------- replacePostBlock -------------------- */
+
+    @Test
+    @DisplayName("replacePostBlock: post 블럭 없으면 새 블럭 추가")
+    void replacePostBlock_noPostBlock() {
+        String original = "pipeline {}";
+        String result = jobNotificationService.replacePostBlock(original, "newPost");
+        assertTrue(result.contains("newPost"));
+    }
+
+    @Test
+    @DisplayName("replacePostBlock: post 블럭 교체 성공")
+    void replacePostBlock_existingPostBlock() {
+        String original = "pipeline { post { } }";
+        String result = jobNotificationService.replacePostBlock(original, "newPost");
+        assertTrue(result.contains("newPost"));
+    }
+
+    @Test
+    @DisplayName("replacePostBlock: post 블럭 닫히지 않으면 예외 발생")
+    void replacePostBlock_unclosedPostBlock() {
+        String original = "pipeline { post { ";
+        assertThrows(IllegalStateException.class, () ->
+                jobNotificationService.replacePostBlock(original, "newPost"));
+    }
+
+    /* -------------------- Credential 관련 메서드 -------------------- */
+
+    @Test
+    @DisplayName("createCredential: Jenkins에 POST 요청 호출")
+    void createCredential_success() {
+        when(httpClientService.buildHeaders(any(), any())).thenReturn(new HttpHeaders());
+        when(httpClientService.exchange(any(), eq(HttpMethod.POST), any(), eq(String.class))).thenReturn(null);
+
+        assertDoesNotThrow(() -> jobNotificationService.createCredential(info, "cred", "secret"));
+        verify(httpClientService, times(1)).exchange(contains("/createCredentials"), eq(HttpMethod.POST), any(), eq(String.class));
+    }
+
+    @Test
+    @DisplayName("updateCredential: 기존 Credential 삭제 후 새로 생성")
+    void updateCredential_success() {
+        when(httpClientService.exchange(any(), eq(HttpMethod.POST), any(), eq(String.class))).thenReturn(null);
+
+        jobNotificationService.updateCredential(info, "cred", "secret");
+        verify(httpClientService, atLeast(2)).exchange(any(), eq(HttpMethod.POST), any(), eq(String.class));
+    }
+
+    @Test
+    @DisplayName("deleteCredential: Jenkins에 Credential 삭제 요청")
+    void deleteCredential_success() {
+        when(httpClientService.buildHeaders(any(), any())).thenReturn(new HttpHeaders());
+        when(httpClientService.exchange(any(), eq(HttpMethod.POST), any(), eq(String.class))).thenReturn(null);
+
+        jobNotificationService.deleteCredential(info, "cred");
+        verify(httpClientService, times(1)).exchange(contains("/doDelete"), eq(HttpMethod.POST), any(), eq(String.class));
+    }
+
+    /* -------------------- getEnabledNotifications -------------------- */
+
+    @Test
+    @DisplayName("getEnabledNotifications: shouldNotify=true인 알림만 조회")
+    void getEnabledNotifications_success() {
+        when(notificationRepository.findByScriptIdAndShouldNotifyTrue(scriptId))
+                .thenReturn(List.of(JobNotification.builder().script(script).shouldNotify(true).build()));
+
+        List<JobNotification> result = jobNotificationService.getEnabledNotifications(script);
+        assertEquals(1, result.size());
+    }
+}

--- a/backend/src/test/java/com/example/backend/jenkins/job/service/ScriptServiceTest.java
+++ b/backend/src/test/java/com/example/backend/jenkins/job/service/ScriptServiceTest.java
@@ -8,6 +8,7 @@ import com.example.backend.jenkins.job.model.Script;
 import com.example.backend.jenkins.job.model.dto.RequestDto;
 import com.example.backend.jenkins.job.model.dto.ResponseDto;
 import com.example.backend.jenkins.job.repository.ScriptRepository;
+import com.example.backend.jenkins.notification.model.JobNotification;
 import com.example.backend.jenkins.notification.service.JobNotificationService;
 import com.example.backend.util.ScriptEditUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +22,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
 @ExtendWith(MockitoExtension.class)
 class ScriptServiceTest {
 
@@ -32,7 +34,7 @@ class ScriptServiceTest {
 
     @InjectMocks private ScriptService scriptService;
 
-    private RequestDto.ScriptBaseDto requestDto;
+    private RequestDto.ScriptBaseDto baseDto;
     private JenkinsInfo jenkinsInfo;
     private Script script;
     private UUID scriptId;
@@ -40,21 +42,21 @@ class ScriptServiceTest {
     @BeforeEach
     void setUp() {
         scriptId = UUID.randomUUID();
-        requestDto = new RequestDto.ScriptBaseDto();
-        requestDto.setScriptId(scriptId);
-        requestDto.setInfoId(UUID.randomUUID());
+        baseDto = new RequestDto.ScriptBaseDto();
+        baseDto.setScriptId(scriptId);
+        baseDto.setInfoId(UUID.randomUUID());
 
         RequestDto.NotificationDto notification = RequestDto.NotificationDto.builder()
-                .channel(com.example.backend.jenkins.notification.model.JobNotification.Channel.SLACK)
-                .eventType(com.example.backend.jenkins.notification.model.JobNotification.EventType.BUILD_FAIL)
+                .channel(JobNotification.Channel.SLACK)
+                .eventType(JobNotification.EventType.BUILD_FAIL)
                 .webhookUrl("webhook")
                 .shouldNotify(true)
                 .credentialName("credId")
                 .build();
-        requestDto.setNotificationList(List.of(notification));
+        baseDto.setNotificationList(List.of(notification));
 
         jenkinsInfo = JenkinsInfo.builder()
-                .id(requestDto.getInfoId())
+                .id(baseDto.getInfoId())
                 .uri("http://jenkins")
                 .build();
 
@@ -65,73 +67,120 @@ class ScriptServiceTest {
     }
 
     @Test
-    @DisplayName("generateScript: scriptId가 존재하지만 DB에 없으면 예외 발생")
+    @DisplayName("generateScript: scriptId 존재하지만 DB에 없으면 예외 발생")
     void generateScript_scriptIdNotFound() {
         when(scriptRepository.existsById(scriptId)).thenReturn(false);
 
         CustomException ex = assertThrows(CustomException.class, () ->
-                scriptService.generateScript(requestDto));
+                scriptService.generateScript(baseDto));
 
         assertEquals(ErrorCode.JENKINS_SCRIPT_NOT_FOUND, ex.getErrorCode());
     }
 
     @Test
-    @DisplayName("generateScript: 기존 scriptId로 정상 생성 및 알림 동기화")
+    @DisplayName("generateScript: 기존 scriptId로 정상 생성 및 알림 동기화 및 스크립트 수정")
     void generateScript_existingScriptId_success() {
         Map<String, Object> context = Map.of("key", "value");
+        List<JobNotification> notis = List.of(
+                JobNotification.builder().eventType(JobNotification.EventType.BUILD_SUCCESS).build()
+        );
 
         when(scriptRepository.existsById(scriptId)).thenReturn(true);
-        when(configService.buildScriptContext(requestDto)).thenReturn(context);
+        when(configService.buildScriptContext(baseDto)).thenReturn(context);
         when(configService.createScript(context)).thenReturn("rawScript");
-        when(scriptEditUtil.injectBooleanParams("rawScript")).thenReturn("editedScript");
-        when(jenkinsInfoService.getJenkinsInfo(requestDto.getInfoId())).thenReturn(jenkinsInfo);
-        when(jobNotificationService.getEnabledNotifications(any())).thenReturn(Collections.emptyList());
-        when(jobNotificationService.updateScriptWithJobNotifications(any(), any()))
-                .thenReturn(script);
+        when(scriptEditUtil.injectBooleanParams("rawScript")).thenReturn("booleanInjectedScript");
+        when(jenkinsInfoService.getJenkinsInfo(baseDto.getInfoId())).thenReturn(jenkinsInfo);
+        when(jobNotificationService.getEnabledNotifications(any())).thenReturn(notis);
+        when(scriptEditUtil.injectNotificationPostBlock("booleanInjectedScript", notis)).thenReturn("finalScript");
+        when(scriptRepository.save(any())).thenReturn(script);
 
-        ResponseDto.LightScriptDto result = scriptService.generateScript(requestDto);
+        ResponseDto.LightScriptDto result = scriptService.generateScript(baseDto);
 
         assertNotNull(result);
         verify(jobNotificationService).syncJobNotifications(any(), eq(jenkinsInfo), any());
+        verify(scriptRepository, times(1)).save(any());
     }
 
     @Test
     @DisplayName("generateScript: 새 script 생성 및 알림 등록")
     void generateScript_newScript_success() {
-        requestDto.setScriptId(null); // 새 script 생성 시나리오
-        Map<String, Object> context = Map.of("key", "value");
+        baseDto.setScriptId(null);
+        Map<String, Object> context = Map.of("x", "y");
+        List<JobNotification> notis = Collections.emptyList();
 
-        when(configService.buildScriptContext(requestDto)).thenReturn(context);
+        UUID newScriptId = UUID.randomUUID();
+        Script newScript = Script.toEntity(baseDto, "booleanInjectedScript");
+        newScript.setId(newScriptId);
+
+        when(configService.buildScriptContext(baseDto)).thenReturn(context);
         when(configService.createScript(context)).thenReturn("rawScript");
-        when(scriptEditUtil.injectBooleanParams("rawScript")).thenReturn("editedScript");
-        when(jenkinsInfoService.getJenkinsInfo(requestDto.getInfoId())).thenReturn(jenkinsInfo);
-        when(scriptRepository.save(any())).thenReturn(script);
-        when(jobNotificationService.getEnabledNotifications(any())).thenReturn(Collections.emptyList());
-        when(jobNotificationService.updateScriptWithJobNotifications(any(), any()))
-                .thenReturn(script);
+        when(scriptEditUtil.injectBooleanParams("rawScript")).thenReturn("booleanInjectedScript");
+        when(scriptRepository.save(any()))
+                .thenReturn(newScript)
+                .thenReturn(newScript); // save 2번
+        when(jenkinsInfoService.getJenkinsInfo(baseDto.getInfoId())).thenReturn(jenkinsInfo);
+        when(jobNotificationService.getEnabledNotifications(any())).thenReturn(notis);
+        when(scriptEditUtil.injectNotificationPostBlock("booleanInjectedScript", notis)).thenReturn("finalScript");
 
-        ResponseDto.LightScriptDto result = scriptService.generateScript(requestDto);
+        ResponseDto.LightScriptDto result = scriptService.generateScript(baseDto);
 
         assertNotNull(result);
-        verify(scriptRepository).save(any());
-        verify(jobNotificationService).createJobNotifications(any(), eq(jenkinsInfo), eq(scriptId));
+        verify(jobNotificationService).createJobNotifications(any(), eq(jenkinsInfo), eq(newScriptId));
+        verify(scriptRepository, times(2)).save(any());
     }
 
     @Test
-    @DisplayName("generateScript: 알림 리스트가 null인 경우 예외 없이 동작")
+    @DisplayName("generateScript: 알림 리스트가 null이면 알림 생성 없이 동작")
     void generateScript_nullNotificationList() {
-        requestDto.setNotificationList(null);
-
-        Map<String, Object> context = Map.of("key", "value");
-
+        baseDto.setNotificationList(null);
         when(scriptRepository.existsById(scriptId)).thenReturn(true);
-        when(configService.buildScriptContext(requestDto)).thenReturn(context);
-        when(configService.createScript(context)).thenReturn("rawScript");
-        when(scriptEditUtil.injectBooleanParams("rawScript")).thenReturn("editedScript");
+        when(configService.buildScriptContext(baseDto)).thenReturn(Map.of());
+        when(configService.createScript(any())).thenReturn("rawScript");
+        when(scriptEditUtil.injectBooleanParams("rawScript")).thenReturn("booleanInjectedScript");
         when(jobNotificationService.getEnabledNotifications(any())).thenReturn(Collections.emptyList());
-        when(jobNotificationService.updateScriptWithJobNotifications(any(), any()))
-                .thenReturn(script);
+        when(scriptEditUtil.injectNotificationPostBlock(any(), any())).thenReturn("finalScript");
+        when(scriptRepository.save(any())).thenReturn(script);
 
-        assertDoesNotThrow(() -> scriptService.generateScript(requestDto));
+        assertDoesNotThrow(() -> scriptService.generateScript(baseDto));
+
+        verify(jobNotificationService, never()).createJobNotifications(any(), any(), any());
+        verify(jobNotificationService, never()).syncJobNotifications(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("validateScript: 유효한 스크립트일 경우 예외 발생하지 않음")
+    void validateScript_valid() {
+        RequestDto.ScriptValidateDto validateDto = new RequestDto.ScriptValidateDto();
+        validateDto.setInfoId(jenkinsInfo.getId());
+        validateDto.setScript("validScript");
+
+        when(jenkinsInfoService.getJenkinsInfo(jenkinsInfo.getId())).thenReturn(jenkinsInfo);
+        when(scriptEditUtil.validateJenkinsfile(jenkinsInfo, "validScript")).thenReturn(true);
+
+        assertDoesNotThrow(() -> scriptService.validateScript(validateDto));
+    }
+
+    @Test
+    @DisplayName("validateScript: 유효하지 않으면 예외 발생")
+    void validateScript_invalid() {
+        RequestDto.ScriptValidateDto validateDto = new RequestDto.ScriptValidateDto();
+        validateDto.setInfoId(jenkinsInfo.getId());
+        validateDto.setScript("invalidScript");
+
+        when(jenkinsInfoService.getJenkinsInfo(jenkinsInfo.getId())).thenReturn(jenkinsInfo);
+        when(scriptEditUtil.validateJenkinsfile(jenkinsInfo, "invalidScript")).thenReturn(false);
+
+        CustomException ex = assertThrows(CustomException.class,
+                () -> scriptService.validateScript(validateDto));
+
+        assertEquals(ErrorCode.JENKINS_SCRIPT_NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("deleteScript: script 삭제 호출")
+    void deleteScript_success() {
+        UUID id = UUID.randomUUID();
+        assertDoesNotThrow(() -> scriptService.deleteScript(id));
+        verify(scriptRepository).deleteById(id);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #224 
> #155 

## 📝작업 내용

✨ **기능 제안 반영 및 리팩토링 작업 수행**  
- `updateScriptWithJobNotifications()`의 단일 책임 원칙(SRP) 위반 문제 해결  
- 스크립트 수정(post 블록 주입) 로직을 `generateUpdatedScriptWithNotifications()`로 분리  
- DB 저장 로직은 호출자(Service)에서 책임지도록 구조 변경  
- JobNotification과 Script 간 연관 관계 리팩토링  

✅ **테스트 코드 수정**  
- 서비스 로직 변경에 따라 기존 `ScriptServiceTest`, `JobNotificationServiceTest` 수정 및 보강  

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

**체크리스트**

- [ ] 코드 컨벤션을 준수했는가? (파일명, 네이밍, 포맷 등)
- [ ] 새로운 기능/버그 수정에 대한 단위 테스트 작성 및 통과했는가?
- [ ] 통합 테스트 및 시나리오 테스트를 통과했는가?
- [ ] 문서(Docs) 업데이트가 필요한 경우 반영했는가?
- [ ] 주요 로직에 적절한 주석이 포함되었는가?
- [ ] 보안/성능 고려 사항 검토했는가?
- [ ] 관련 브랜치 전략 및 머지 대상이 적절한가?
